### PR TITLE
Merge in Select mpa-sil Tweaks

### DIFF
--- a/lib/edit/artefact.txt
+++ b/lib/edit/artefact.txt
@@ -1516,8 +1516,7 @@ F:INDESTRUCTIBLE
 F:INSTA_ART 
 D:Containing much of the power of he who is the mightiest among the
 D: Ainur, this plain iron crown has mounted upon it the three
-D: Silmarils, greatest treasures of Middle-Earth. To attempt to cut
-D: a Silmaril from the crown, stand over it and press (k).
+D: Silmarils, greatest treasures of Middle-Earth.
 
 
 ## The Mighty Hammer 'Grond'

--- a/lib/edit/race.txt
+++ b/lib/edit/race.txt
@@ -54,7 +54,8 @@ H:82:4:70:2
 W:165:10:153:10
 C:1|2|3
 F:BLADE_PROFICIENCY | ARC_AFFINITY
-E:39:0:3:4     # ~ Wooden Torches (3-4)
+E:23:7:1:1     # | Curved Sword
+E:39:0:4:4     # ~ Wooden Torches (4)
 E:80:37:3:3    # , Fragment of Lembas (3)
 D:The Noldor are known as the 'Deep-elves', for they are the
 D: most learned and inventive of the elven kindreds. They saw
@@ -76,7 +77,8 @@ H:77:4:68:2
 W:159:10:153:10
 C:4|10
 F:BLADE_PROFICIENCY | ARC_AFFINITY
-E:39:0:3:4     # ~ Wooden Torches (3-4)
+E:23:7:1:1     # | Curved Sword
+E:39:0:4:4     # ~ Wooden Torches (4)
 E:80:37:3:3    # , Fragment of Lembas (3)
 D:The Sindar are the 'Grey-elves' who never saw the blessed light of
 D: the Two Trees, but who found an echo of it in their queen,
@@ -97,7 +99,8 @@ H:51:3:49:2
 W:160:10:150:10
 C:5|6
 F:AXE_PROFICIENCY | ARC_PENALTY | SMT_AFFINITY
-E:39:0:3:4     # ~ Wooden Torches (3-4)
+E:23:7:1:1     # | Curved Sword
+E:39:0:4:4     # ~ Wooden Torches (4)
 E:80:35:5:5    # , Pieces of Dark Bread (5)
 D:The dwarves are stone-hard and stubborn, fast in friendship
 D: and in enmity. They live long, far beyond the span of Men
@@ -116,7 +119,8 @@ I:21:15:45
 H:75:4:68:2
 W:176:14:156:14
 C:7|8|9
-E:39:0:3:4     # ~ Wooden Torches (3-4)
+E:23:7:1:1     # | Curved Sword
+E:39:0:4:4     # ~ Wooden Torches (4)
 E:80:35:5:5    # , Pieces of Dark Bread (5)
 D:The Edain are the Men of Beleriand. They gained much from
 D: dealings with the Noldor, and grew more long lived than their

--- a/lib/edit/terrain.txt
+++ b/lib/edit/terrain.txt
@@ -68,7 +68,7 @@ G:':U
 # 0x05 --> broken door
 
 N:5:broken door
-G:.:U
+G:':s
 
 # 0x06 --> warded door (power 1)
 

--- a/src/birth.c
+++ b/src/birth.c
@@ -670,6 +670,9 @@ static void player_outfit(void)
 			object_prep(i_ptr, k_idx);
 			i_ptr->number = (byte)rand_range(e_ptr->min, e_ptr->max);
 
+			// Make it always the typical weight (for weapons).
+			i_ptr->weight = k_info[i_ptr->k_idx].weight;
+
 			//object_aware(i_ptr);
 			//object_known(i_ptr);
 		}

--- a/src/cave.c
+++ b/src/cave.c
@@ -538,11 +538,11 @@ bool feat_supports_lighting(int feat)
 
 static byte darken(byte a, byte c)
 {
-	// don't darken the symbols for traps
-	if (c == '^') return (a);
-
-	// or chasms or shafts
-	if (((c == '%') || (c == '>') || (c == '<')) && a == TERM_L_DARK) return (a);
+	// don't darken the symbols for traps, stairs, chasms, or shafts
+	if (c == '^' || c == '>' || c == '<' || c == ';')
+	{
+		return (a);
+	}
 
 	if (a == TERM_WHITE)                    return (TERM_SLATE);
 	if (a == TERM_L_WHITE)                  return (TERM_L_DARK);

--- a/src/cmd1.c
+++ b/src/cmd1.c
@@ -2562,6 +2562,8 @@ void py_pickup(void)
 
 	char o_name[80];
 
+	bool done_pickup = FALSE;
+
  	/* Automatically destroy squelched items in pile if necessary */
 	do_squelch_pile(py, px);
 
@@ -2614,8 +2616,15 @@ void py_pickup(void)
         
 		/* Pick up the object */
 		py_pickup_aux(this_o_idx);
+		done_pickup = TRUE;
 	}
 
+	// Don't spend a turn if we couldn't pick anything up.
+	if (!done_pickup)
+	{
+		p_ptr->previous_action[0] = ACTION_NOTHING;
+		p_ptr->energy_use = 0;
+	}
 }
 
 

--- a/src/cmd1.c
+++ b/src/cmd1.c
@@ -5315,6 +5315,15 @@ static bool run_test(void)
 		{
 			/* Primary option */
 			p_ptr->run_cur_dir = option;
+
+                        /* Stop in the doorway of a room */
+                        row = py + 2*ddy[option];
+                        col = px + 2*ddx[option];
+                        if ((cave_info[row][col] & CAVE_MARK) &&
+                            !cave_wall_bold(row,col))
+			{
+			        return (TRUE);
+			}
 			
 			/* Hack -- allow curving */
 			p_ptr->run_old_dir = option2;

--- a/src/cmd1.c
+++ b/src/cmd1.c
@@ -1042,6 +1042,11 @@ extern void ident_on_wield(object_type *o_ptr)
 		notice = TRUE;
 		msg_print("It speeds your movement.");
 	}
+	else if (f2 & (TR2_REGEN))
+	{
+		notice = TRUE;
+		msg_print("You notice that you are recovering much faster than usual.");
+	}
 
 	else if (f1 & (TR1_DAMAGE_SIDES))
 	{
@@ -1531,7 +1536,7 @@ extern void ident_passive(void)
 				notice = TRUE;
 				my_strcpy(effect_string, "You notice that you are recovering much faster than usual.", sizeof (effect_string));
 			}
-			else if ((f2 & (TR2_AGGRAVATE)))
+			else if (f2 & (TR2_AGGRAVATE))
 			{
 				notice = TRUE;
 				my_strcpy(effect_string, "You notice that you are enraging your enemies.", sizeof (effect_string));

--- a/src/cmd1.c
+++ b/src/cmd1.c
@@ -2415,6 +2415,7 @@ void py_pickup_aux(int o_idx)
 	int slot;
 
 	char o_name[80];
+	char depth[80];
 	object_type *o_ptr;
 
 	o_ptr = &o_list[o_idx];
@@ -2427,6 +2428,16 @@ void py_pickup_aux(int o_idx)
 
 		/* Get the object again */
 		o_ptr = &inventory[slot];
+
+		// Inscribe consumables with current depth.
+		if (!object_known_p(o_ptr)
+			&& !o_ptr->obj_note
+			&& (o_ptr->tval == TV_POTION
+				|| o_ptr->tval == TV_FOOD))
+		{
+			sprintf(depth, "%d ft", p_ptr->depth * 50);
+			add_autoinscription(o_ptr->k_idx, depth);
+		}
 
 		/* Describe the object */
 		object_desc(o_name, sizeof(o_name), o_ptr, TRUE, 3);

--- a/src/cmd1.c
+++ b/src/cmd1.c
@@ -2600,6 +2600,38 @@ void py_pickup(void)
 			next_o_idx = 0;
 			continue;
 		}
+		// Special case for prising Silmarils from the Iron Crown of Morgoth
+		if ((o_ptr->name1 >= ART_MORGOTH_1) && (o_ptr->name1 <= ART_MORGOTH_3))
+		{
+			// Select the melee weapon
+			o_ptr = &inventory[INVEN_WIELD];
+
+			// No weapon
+			if (!o_ptr->k_idx)
+			{
+				msg_print("To prise a Silmaril from the crown, you would need to wield a weapon.");
+			}
+
+			// Wielding a weapon
+			else
+			{
+				if (get_check("Will you try to prise a Silmaril from the Iron Crown? "))
+				{
+					prise_silmaril();
+
+					/* Take a turn */
+					p_ptr->energy_use = 100;
+
+					// store the action type
+					p_ptr->previous_action[0] = ACTION_MISC;
+
+					return;
+				}
+			}
+
+			continue;
+		}
+
 
 		/* Note that the pack is too full */
 		if (!inven_carry_okay(o_ptr))

--- a/src/cmd1.c
+++ b/src/cmd1.c
@@ -996,7 +996,13 @@ extern void ident_on_wield(object_type *o_ptr)
 	{
 		notice = TRUE;
 	}
-    
+
+	// Also always identify tunneling since it's never ambiguous.
+	if (f1 & (TR1_TUNNEL))
+	{
+		notice = TRUE;
+	}
+
 	if (o_ptr->name1 || o_ptr->name2)
 	{
 		// For special items and artefacts, we need to ignore the flags that are basic 

--- a/src/cmd3.c
+++ b/src/cmd3.c
@@ -919,9 +919,6 @@ void prise_silmaril(void)
 	int crit_bonus_dice = 0;
 	int pd = 20;
 
-	// will check
-	bool will_test_passed = FALSE;
-
 	int noise = 0;
 	u32b dummy_noticed_flag;
 	

--- a/src/cmd3.c
+++ b/src/cmd3.c
@@ -1132,8 +1132,7 @@ void prise_silmaril(void)
 	// check for taking of final Silmaril
 	if (o_ptr->name1 == ART_MORGOTH_1 && freed)
 	{
-		msg_print("Until you escape you must now roll twice for every skill check, taking the worse result each time.");
-		msg_print("You hear a cry of veangance echo through the iron hells.");
+		msg_print("You hear a cry of vengeance echo through the iron hells.");
 		wake_all_monsters(0);
 	}
 }

--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -752,7 +752,7 @@ static u32b bane_flag[] =
 	RF3_DRAGON
 };
 
-static char *bane_name[] =
+char *bane_name[] =
 {
 	"Nothing",
 	"Orc",

--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -5060,7 +5060,7 @@ int smithing_menu_aux(int *highlight)
                                  (smith_o_ptr->tval != TV_HORN) &&
                                  (p_ptr->self_made_arts < z_info->art_self_made_max - z_info->art_rand_max - 2);
 	valid[SMT_MENU_NUMBERS-1]  = (smith_o_ptr->tval != 0);
-	valid[SMT_MENU_MELT-1]     = mithril_items_carried() && cave_forge_bold(p_ptr->py, p_ptr->px) && (forge_uses(p_ptr->py, p_ptr->px) > 0);
+	valid[SMT_MENU_MELT-1]     = mithril_items_carried() && cave_forge_bold(p_ptr->py, p_ptr->px);
 	valid[SMT_MENU_ACCEPT-1]   = affordable(smith_o_ptr) && cave_forge_bold(p_ptr->py, p_ptr->px) && (forge_uses(p_ptr->py, p_ptr->px) > 0);
 	
 

--- a/src/cmd6.c
+++ b/src/cmd6.c
@@ -407,6 +407,12 @@ void do_cmd_activate_staff(object_type *default_o_ptr, int default_item)
 		}
 	}
 
+	if (o_ptr->ident & (IDENT_EMPTY))
+	{
+		msg_print("The staff has no charges left.");
+		return;
+	}
+
 	/* Take a turn */
 	p_ptr->energy_use = 100;
 

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -895,11 +895,11 @@ static void process_command(void)
 		}
 
 		/* Destroy an item */
-		case 'k':
-		{
-			do_cmd_destroy();
-			break;
-		}
+		//case 'k':
+		//{
+		//	do_cmd_destroy();
+		//	break;
+		//}
 
 		/* Equipment list */
 		case 'e':

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -757,38 +757,12 @@ static bool enter_wizard_mode(void)
  */
 static bool verify_debug_mode(void)
 {
-	char buf[80] = "It is not mellon";
-	
 	/* Ask first time */
 	if (!(p_ptr->noscore & 0x0008))
 	{
-		/* Mention effects */
-		msg_print("You are about to use the dangerous, unsupported, debug commands!");
-		msg_print("Your machine may crash, and your savefile may become corrupted!");
-		message_flush();
-
 		/* Verify request */
 		if (!get_check("Are you sure you want to use the debug commands? "))
 		{
-			return (FALSE);
-		}
-		
-		// ask for password in deployment versions
-		if (DEPLOYMENT)
-		{
-			if (term_get_string("Password: ", buf, sizeof(buf)))
-			{
-				if (strcmp(buf,"Gondolin") == 0)
-				{
-					/* Mark savefile */
-					p_ptr->noscore |= 0x0008;
-					
-					/* Okay */
-					return (TRUE);
-				}
-			}
-			
-			msg_print("Incorrect password.");
 			return (FALSE);
 		}
 	}

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -2625,7 +2625,7 @@ static void dungeon(void)
 	if ((p_ptr->depth == MORGOTH_DEPTH) && p_ptr->truce)
 	{
 		msg_print("There is a strange tension in the air.");
-		if (p_ptr->skill_use[S_PER] >= 15) msg_print("You feel that Morgoth's servants are reluctant to attack before he delivers judgment.");	
+		msg_print("You feel that Morgoth's servants are reluctant to attack before he delivers judgement.");
 	}
 
 	/*** Process this dungeon level ***/

--- a/src/externs.h
+++ b/src/externs.h
@@ -401,7 +401,6 @@ extern void do_cmd_equip(void);
 extern void do_cmd_wield(object_type *default_o_ptr, int default_item);
 extern void do_cmd_takeoff(object_type *default_o_ptr, int default_item);
 extern void do_cmd_drop(void);
-extern void shatter_weapon(int silnum);
 extern void prise_silmaril(void);
 extern void do_cmd_destroy(void);
 extern void do_cmd_observe(void);

--- a/src/externs.h
+++ b/src/externs.h
@@ -401,6 +401,8 @@ extern void do_cmd_equip(void);
 extern void do_cmd_wield(object_type *default_o_ptr, int default_item);
 extern void do_cmd_takeoff(object_type *default_o_ptr, int default_item);
 extern void do_cmd_drop(void);
+extern void shatter_weapon(int silnum);
+extern void prise_silmaril(void);
 extern void do_cmd_destroy(void);
 extern void do_cmd_observe(void);
 extern void do_cmd_uninscribe(void);

--- a/src/externs.h
+++ b/src/externs.h
@@ -425,6 +425,7 @@ extern void do_cmd_character_sheet(void);
 extern void do_cmd_change_song(void);
 extern int ability_index(int skilltype, int abilitynum);
 extern int elf_bane_bonus(monster_type *m_ptr);
+extern char *bane_name[];
 extern int bane_bonus(monster_type *m_ptr);
 extern int spider_bane_bonus(void);
 extern void do_cmd_ability_screen(void);

--- a/src/files.c
+++ b/src/files.c
@@ -4335,7 +4335,9 @@ errr file_character(cptr name, bool full)
 	char o_name[80];
 	
 	char buf[1024];
-	
+
+	ability_type *b_ptr;
+
 	int holder;
 	
 	bool challenges = FALSE;
@@ -4512,9 +4514,27 @@ errr file_character(cptr name, bool full)
 		/* Describe random object attributes */
 		identify_random_gen(o_ptr);
 	}
-	fprintf(fff, "\n");
-	
-	fprintf(fff, "\n  [Notes]\n\n");
+
+	// Dump abilities.
+	fprintf(fff, "\n\n  [Abilities]\n\n");
+	for (i = 0; i < z_info->b_max; i++)
+	{
+		b_ptr = &b_info[i];
+
+		if (!b_ptr->name) continue;
+
+		if (p_ptr->innate_ability[b_ptr->skilltype][b_ptr->abilitynum])
+		{
+			if (b_ptr->skilltype == S_PER && b_ptr->abilitynum == PER_BANE && p_ptr->bane_type > 0)
+			{
+				fprintf(fff, "%s-%s\n", bane_name[p_ptr->bane_type], (b_name + b_ptr->name));
+			}
+			else
+				fprintf(fff, "%s\n", (b_name + b_ptr->name));
+		}
+	}
+
+	fprintf(fff, "\n\n  [Notes]\n\n");
 	
 	/*dump notes to character file*/
 	i = 0;

--- a/src/files.c
+++ b/src/files.c
@@ -4534,6 +4534,32 @@ errr file_character(cptr name, bool full)
 		}
 	}
 
+	// Dump found artefacts if dead.
+	if (p_ptr->is_dead)
+	{
+		fprintf(fff, "\n\n  [Artefacts]\n\n");
+
+		// Just go to the end of the normal artefacts list, don't also grab
+		// forged artefacts.
+		for (i = 0; i < z_info->art_norm_max; i++)
+		{
+			char o_name[120];
+			artefact_type *a_ptr;
+			object_type *o_ptr;
+			object_type object_type_body;
+			o_ptr = &object_type_body;
+
+			a_ptr = &a_info[i];
+			if (a_ptr->cur_num == 0) continue;
+
+			make_fake_artefact(o_ptr, i);
+			object_desc_spoil(o_name, sizeof(o_name), o_ptr, TRUE, 0);
+
+			fprintf(fff, "%s %s\n", o_name, a_ptr->found_num > 0 ? "(found)" : "");
+		}
+	}
+
+
 	fprintf(fff, "\n\n  [Notes]\n\n");
 	
 	/*dump notes to character file*/

--- a/src/files.c
+++ b/src/files.c
@@ -2827,9 +2827,6 @@ void show_help_screen(int i)
 			else				c_put_str(TERM_WHITE, "^t",  row, col - 1);
 			c_put_str(TERM_SLATE, "throw (auto-target)", row, col + 2);
 			row++;
-			c_put_str(TERM_WHITE, "k",                      row, col);
-			c_put_str(TERM_SLATE, "destroy",                row, col + 2);
-			row++;
 			c_put_str(TERM_WHITE, "{",                      row, col);
 			c_put_str(TERM_SLATE, "inscribe",               row, col + 2);
 			row++;

--- a/src/files.c
+++ b/src/files.c
@@ -4559,6 +4559,32 @@ errr file_character(cptr name, bool full)
 		}
 	}
 
+	fprintf(fff, "\n\n  [Enemies]\n\n");
+
+	for (i = 1; i < z_info->r_max - 1; i++)
+	{
+		monster_race *r_ptr = &r_info[i];
+		monster_lore *l_ptr = &l_list[i];
+
+		if (!l_ptr->psights && !l_ptr->pkills) {
+			continue;
+		}
+
+		if (r_ptr->flags1 & (RF1_UNIQUE))
+		{
+			/* Print a message */
+			fprintf(fff, "  %-7s %s \n",
+			l_ptr->pkills ? "(slain)" : "(seen)",
+					(r_name + r_ptr->name));
+		}
+		else
+		{
+			/* Print a message */
+			fprintf(fff, "%3d /%3d  %-40s\n",
+					l_ptr->pkills, l_ptr->psights, (r_name + r_ptr->name));
+		}
+	}
+
 
 	fprintf(fff, "\n\n  [Notes]\n\n");
 	

--- a/src/files.c
+++ b/src/files.c
@@ -4713,6 +4713,29 @@ static void close_game_aux(void)
 	p_ptr->rage = 0;
 	p_ptr->image = 0;
 
+	// Automatic character dump
+	char curr_time[30], sheet[60];
+	time_t ct = time((time_t*)0);
+	(void)strftime(curr_time, 30, "%Y%m%d-%H%M%S.txt", localtime(&ct));
+	sprintf(sheet, "%s-%s", op_ptr->full_name, curr_time);
+	errr err;
+	// Save the screen
+	screen_save();
+	// Dump a character file
+	err = file_character(sheet, FALSE);
+	// Load the screen
+	screen_load();
+	// Check result
+	if (err)
+	{
+		// Clear screen
+		Term_clear();
+		// Warning
+		msg_print("Automatic character dump failed!");
+		// Flush messages
+		message_flush();
+	}
+
 	/* You are dead */
 	print_tomb(&the_score);
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -3491,10 +3491,12 @@ static bool cave_gen(void)
 		}
 	}
 
-	// add a curved sword near the player if this is the beginning of the game
-	if (playerturn == 0)
+	/* Put some objects in rooms */	
+	obj_room_gen = 3 * mon_gen / 4;
+	if (obj_room_gen > 0) 
 	{
-		place_item_randomly(TV_SWORD, SV_CURVED_SWORD, TRUE);
+		// currently ignoring the above...
+		alloc_object(ALLOC_SET_ROOM, ALLOC_TYP_OBJECT, obj_room_gen, FALSE);
 	}
 
 	return (TRUE);

--- a/src/monster2.c
+++ b/src/monster2.c
@@ -1823,13 +1823,6 @@ void describe_floor_object(void)
         /* Disturb */
         disturb(0,0);
     }
-    
-    // special explanation the first time you step over the crown
-    if ((o_ptr->name1 == ART_MORGOTH_3) && !(p_ptr->crown_hint))
-    {
-        msg_print("To attempt to prise a Silmaril from the crown, use the 'destroy' command (which is 'k' by default).");
-        p_ptr->crown_hint = TRUE;
-    }
 }
 
 

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -469,7 +469,7 @@ static bool describe_misc_magic(const object_type *o_ptr, u32b f2, u32b f3)
 	if (f2 & (TR2_SLOW_DIGEST))								good[gc++] = "reduces your need for food";
 	if ((f2 & (TR2_RADIANCE)) && (o_ptr->tval == TV_BOW))	good[gc++] = "fires shining arrows";
 	if ((f2 & (TR2_RADIANCE)) && (o_ptr->tval == TV_BOOTS))	good[gc++] = "lights your path behind you";
-	if (f2 & (TR2_REGEN))									good[gc++] = "speeds your regeneration (which also increases your hunger)";
+	if (f2 & (TR2_REGEN))									good[gc++] = "speeds your regeneration (which increases your hunger while active)";
 
 	/* Describe */
 	output_desc_list("It ", good, gc);

--- a/src/object2.c
+++ b/src/object2.c
@@ -799,9 +799,6 @@ void object_known(object_type *o_ptr)
 	/* The object is not "sensed" */
 	o_ptr->ident &= ~(IDENT_SENSE);
 
-	/* Clear the "Empty" info */
-	o_ptr->ident &= ~(IDENT_EMPTY);
-
 	/* Now we know about the item */
 	o_ptr->ident |= (IDENT_KNOWN);
 }

--- a/src/xtra1.c
+++ b/src/xtra1.c
@@ -2499,8 +2499,13 @@ static void calc_bonuses(void)
 	if (p_ptr->pspeed < 1) p_ptr->pspeed = 1;
 	if (p_ptr->pspeed > 3) p_ptr->pspeed = 3;
 	
-	// Increase food consumption if regenerating
-	if (p_ptr->regenerate) p_ptr->hunger += 1;
+	// Increase food consumption if (actively) regenerating.
+	// note that each item with the speed flag has already increased hunger
+	if (p_ptr->regenerate &&
+		(p_ptr->chp < p_ptr->mhp || p_ptr->csp < p_ptr->msp))
+	{
+		p_ptr->hunger += 1;
+	}
 
 	/* armour weight (not inventory weight reduces stealth */
 	/* by 1 point per 10 pounds (rounding down) */

--- a/src/xtra1.c
+++ b/src/xtra1.c
@@ -2862,10 +2862,16 @@ void update_lore_aux(object_type *o_ptr)
 		bool foodOrPotion = o_ptr->tval == TV_FOOD || o_ptr->tval == TV_POTION;
 		bool enchantedItem = !staffOrHorn && !foodOrPotion &&
 				o_ptr->tval != TV_CHEST && o_ptr->tval != TV_SKELETON;
+		// Artefacts are identified on sight as they always have the same effects
+		bool artefact = o_ptr->name1;
+		// Miruvor/Orcish Liquor ID'd on sight as they always have the same flavour
+		bool knownPotion = o_ptr->tval == TV_POTION &&
+			(o_ptr->sval == SV_POTION_MIRUVOR ||
+			 o_ptr->sval == SV_POTION_ORCISH_LIQUOR);
 
-		if ((channeling && staffOrHorn) ||
+		if ((channeling && staffOrHorn) || knownPotion ||
                     (alchemy && (staffOrHorn || foodOrPotion)) ||
-                    (enchantment && enchantedItem))
+                    (enchantment && enchantedItem) || artefact)
 		{
 			ident(o_ptr);
 		}

--- a/src/xtra2.c
+++ b/src/xtra2.c
@@ -2163,7 +2163,7 @@ void monster_death(int m_idx)
 	{
 		p_ptr->morgoth_slain = TRUE;
 		msg_print("BUG: Morgoth has been defeated in combat.");
-		msg_print("But this is not possible within the fates Illuvatar has decreed.");
+		msg_print("But this is not possible within the fates Iluvatar has decreed.");
 		msg_print("Please post an 'ultimate bug-report' on http://angband.oook.cz/forum/ explaining how this happened.");
 		msg_print("But for now, let's run with it, since it's undeniably impressive.");
 

--- a/src/xtra2.c
+++ b/src/xtra2.c
@@ -3545,12 +3545,20 @@ static int target_set_interactive_aux(int y, int x, int mode, cptr info)
 				if (o_ptr->marked)
 				{
 					char o_name[80];
+					char weight[80] = "";
 
 					/* Not boring */
 					boring = FALSE;
 
 					/* Obtain an object description */
 					object_desc(o_name, sizeof(o_name), o_ptr, TRUE, 3);
+
+					if (o_ptr->weight)
+					{
+						int wgt = o_ptr->weight * o_ptr->number;
+						sprintf(weight, " (%d.%1d lb)", wgt / 10, wgt % 10);
+					}
+
 
 					/* Describe the object */
 					if (p_ptr->wizard)
@@ -3562,7 +3570,7 @@ static int target_set_interactive_aux(int y, int x, int mode, cptr info)
 					else
 					{
 						strnfmt(out_val, sizeof(out_val),
-								"%s%s%s%s %s [%s]", s1, s2, s3, o_name, more, info);
+								"%s%s%s%s%s %s [%s]", s1, s2, s3, o_name, weight, more, info);
 					}
 
 					prt(out_val, 0, 0);

--- a/src/xtra2.c
+++ b/src/xtra2.c
@@ -2519,9 +2519,10 @@ void verify_panel(void)
 
 
 	/* Scroll screen vertically when off-center */
-	if (center_player && (!p_ptr->running || !run_avoid_center))
+	if (center_player && (!p_ptr->running || !run_avoid_center)
+			&& px != wx + SCREEN_WID / 2)
 	{
-		wy = py - SCREEN_HGT / 2;
+		wx = px - SCREEN_WID / 2;
 	}
 
 

--- a/src/xtra2.c
+++ b/src/xtra2.c
@@ -2519,10 +2519,9 @@ void verify_panel(void)
 
 
 	/* Scroll screen vertically when off-center */
-	if (center_player && (!p_ptr->running || !run_avoid_center)
-			&& px != wx + SCREEN_WID / 2)
+	if (center_player && (!p_ptr->running || !run_avoid_center))
 	{
-		wx = px - SCREEN_WID / 2;
+		wy = py - SCREEN_HGT / 2;
 	}
 
 


### PR DESCRIPTION
I think these are all reasonable and minor changes made in the mpa-sil fork.

**Interface:**
- Glyph changes
- Weights of floor items
- Prompt to step beside immobile monsters
- Force uppercase Y/N on vi keys
- Running stops in doorways

**Convenience:**
- Starting with the sword equipped and always the same weight
- IDing glowing weapons, booze, and healing items
- Not wasting turns (for empty staves, when picking up with a full inventory)
- Allowing melting mithril in exhausted forges
- Regeneration not consuming hunger at full HP

**Dumps/Inscriptions:**
- Killed/Seen counts
- Artifact and skill areas
- Consumable inscriptions
- Automatic dumps

Of these, I think that the only questionable one may be the "prompt on moving next to immobiles" since statdrain molds are no longer a thing, and the only significant immobile thing to move beside now is a yellow & during a fight.