### PR TITLE
parse ANGBAND_DIR_USER in updatecharinfoS

### DIFF
--- a/src/save.c
+++ b/src/save.c
@@ -19,7 +19,9 @@ void updatecharinfoS(void)
 	char tmp_Path[1024];
 	FILE *oFile;
 	int curDepth = p_ptr->max_depth * 50 ;
-	path_build(tmp_Path, sizeof(tmp_Path), ANGBAND_DIR_USER, "CharOutput.txt");
+	char parsed_dir_user[1024];
+	path_parse(parsed_dir_user, sizeof(parsed_dir_user), ANGBAND_DIR_USER);
+	path_build(tmp_Path, sizeof(tmp_Path), parsed_dir_user, "CharOutput.txt");
 	oFile = fopen(tmp_Path, "w");
 	fprintf(oFile, "{\n");
 	fprintf(oFile, "race: \"%s\",\n", races[p_ptr->prace]);


### PR DESCRIPTION
This allows using PRIVATE_USER_PATH with paths relative to the home directory (like the example "~/.sil" in config.h).
I wanted to have my saves stored in ~/.local/share/sil-q, but setting PRIVATE_USER_PATH to that resulted in a segfault because the path could not be found.

As an aside, should i set it to ~/.local/share/sil-q or ~/.local/share/? As of now ~/.local/share/sil-q only contains the Sil-Q directory and no other file, but I don't know if that's guaranteed to happen or other files haven't been created yet.