### PR TITLE
OS X: apply some user-visible fixes

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3994,26 +3994,38 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
     
 }
 
-/* Delegate method that gets called if we're asked to open a file. */
-- (BOOL)application:(NSApplication *)sender openFiles:(NSArray *)filenames
+/**
+ * Delegate method that gets called if we're asked to open a file.
+ */
+- (void)application:(NSApplication *)sender openFiles:(NSArray *)filenames
 {
     /* Can't open a file once we've started */
-    if (game_in_progress) return NO;
-    
+    if (game_in_progress) {
+        [[NSApplication sharedApplication]
+            replyToOpenOrPrint:NSApplicationDelegateReplyFailure];
+        return;
+    }
+
     /* We can only open one file. Use the last one. */
     NSString *file = [filenames lastObject];
-    if (! file) return NO;
-    
+    if (! file) {
+        [[NSApplication sharedApplication]
+            replyToOpenOrPrint:NSApplicationDelegateReplyFailure];
+        return;
+    }
+
     /* Put it in savefile */
-    if (! [file getFileSystemRepresentation:savefile maxLength:sizeof savefile]) return NO;
-    
-    /* Success, remember to load it */
-    ////cmd.command = CMD_LOADFILE;
-    
+    if (! [file getFileSystemRepresentation:savefile maxLength:sizeof savefile]) {
+        [[NSApplication sharedApplication]
+            replyToOpenOrPrint:NSApplicationDelegateReplyFailure];
+        return;
+    }
+
     /* Wake us up in case this arrives while we're sitting at the Welcome screen! */
     wakeup_event_loop();
-    
-    return YES;
+
+    [[NSApplication sharedApplication]
+        replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
 }
 
 @end

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4021,8 +4021,14 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
         return;
     }
 
+    game_in_progress = TRUE;
+    new_game = FALSE;
+
     /* Wake us up in case this arrives while we're sitting at the Welcome screen! */
     wakeup_event_loop();
+    if (initialized) {
+        Term_keypress(ESCAPE);
+    }
 
     [[NSApplication sharedApplication]
         replyToOpenOrPrint:NSApplicationDelegateReplySuccess];

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1090,6 +1090,9 @@ static void create_user_dir(void)
     // initialize file paths
     [self prepareFilePathsAndDirectories];
 
+    /* Note the "system" */
+    ANGBAND_SYS = "mac";
+
     // load preferences
     load_prefs();
     
@@ -1107,9 +1110,6 @@ static void create_user_dir(void)
     
 	/* Register the sound hook */
 ////	sound_hook = play_sound;
-    
-    /* Note the "system" */
-    ANGBAND_SYS = "mac";
     
     /* Initialize some save file stuff */
     player_egid = getegid();


### PR DESCRIPTION
They are:
* constrain the minimum sizes for the windows
* allow dragging a save file to the application or selecting "Open with..." on a save file to start the game and open the save
* set ANGBAND_SYS before load_prefs() so the *-mac.prf files will be used.