### PR TITLE
OS X: other changes to align with Angband's OS X code

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -158,6 +158,9 @@ static NSFont *default_font;
     wchar_t *charOverdrawCache;
     int *attrOverdrawCache;
 
+    /* Flags whether or not a fullscreen transition is in progress. */
+    BOOL in_fullscreen_transition;
+
 @private
 
     BOOL _hasSubwindowFlags;
@@ -843,7 +846,9 @@ static int compare_advances(const void *ap, const void *bp)
         
         /* Allocate our array of views */
         angbandViews = [[NSMutableArray alloc] init];
-        
+
+        self->in_fullscreen_transition = NO;
+
         /* Make the image. Since we have no views, it'll just be a puny 1x1 image. */
         [self updateImage];
 
@@ -1493,24 +1498,36 @@ static NSMenuItem *superitem(NSMenuItem *self)
 {
     NSWindow *window = [notification object];
     NSRect contentRect = [window contentRectForFrameRect: [window frame]];
-    [self resizeTerminalWithContentRect: contentRect saveToDefaults: YES];
+    [self resizeTerminalWithContentRect: contentRect saveToDefaults: !(self->in_fullscreen_transition)];
 }
 
 //- (NSSize)windowWillResize: (NSWindow *)sender toSize: (NSSize)frameSize
 //{
 //}
 
+- (void)windowWillEnterFullScreen: (NSNotification *)notification
+{
+    self->in_fullscreen_transition = YES;
+}
+
 - (void)windowDidEnterFullScreen: (NSNotification *)notification
 {
     NSWindow *window = [notification object];
     NSRect contentRect = [window contentRectForFrameRect: [window frame]];
+    self->in_fullscreen_transition = NO;
     [self resizeTerminalWithContentRect: contentRect saveToDefaults: NO];
+}
+
+- (void)windowWillExitFullScreen: (NSNotification *)notification
+{
+    self->in_fullscreen_transition = YES;
 }
 
 - (void)windowDidExitFullScreen: (NSNotification *)notification
 {
     NSWindow *window = [notification object];
     NSRect contentRect = [window contentRectForFrameRect: [window frame]];
+    self->in_fullscreen_transition = NO;
     [self resizeTerminalWithContentRect: contentRect saveToDefaults: NO];
 }
 

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3165,9 +3165,12 @@ static void AngbandHandleEventMouseDown( NSEvent *event )
 		// Coordinates run from (0,0) to (cols-1, rows-1).
 		BOOL mouseInMapSection = (x > 13 && x <= cols - 1 && y > 0  && y <= rows - 2);
 
-		// if we are displaying a menu, allow clicks anywhere; if we are displaying the main
-		// game interface, only allow clicks in the map section
-		if (!displayingMapInterface || (displayingMapInterface && mouseInMapSection))
+		// if we are displaying a menu, allow clicks anywhere within
+		// the terminal bounds; if we are displaying the main game
+		// interface, only allow clicks in the map section
+		if ((!displayingMapInterface && x >= 0 && x < cols &&
+			y >= 0 && y < rows) ||
+			(displayingMapInterface && mouseInMapSection))
 		{
 			// [event buttonNumber] will return 0 for left click, 1 for right click, but this is safer
 			int button = ([event type] == NSLeftMouseDown) ? 1 : 2;

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1584,7 +1584,13 @@ static NSMenuItem *superitem(NSMenuItem *self)
 
 - (void)windowWillClose: (NSNotification *)notification
 {
-	[self saveWindowVisibleToDefaults: NO];
+    /*
+     * If closing only because the application is terminating, don't update
+     * the visible state for when the application is relaunched.
+     */
+    if (! quit_when_ready) {
+        [self saveWindowVisibleToDefaults: NO];
+    }
 }
 
 @end
@@ -3913,6 +3919,7 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
 {
     if (p_ptr->playing == FALSE || game_is_finished == TRUE)
     {
+        quit_when_ready = true;
         return NSTerminateNow;
     }
     else if (! inkey_flag)

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2584,7 +2584,10 @@ static term *term_data_link(int i)
 
     /* Use a "software" cursor */
     newterm->soft_cursor = TRUE;
-    
+
+    /* Disable the per-row flush notifications since they are not used. */
+    newterm->never_frosh = TRUE;
+
     /* Erase with "white space" */
     newterm->attr_blank = TERM_WHITE;
     newterm->char_blank = ' ';


### PR DESCRIPTION
These are a very minor optimization and fixes for problems that affected the OS X version of Angband but which do not appear to be problems in Sil-Q.  Bringing them over to Sil-Q since they don't appear to break anything and will hopefully make it easier to compare the two versions or prevent problems in the future if a change in the core of Sil-Q makes the OS X interface vulnerable to an issue that affected Angband.  The changes are:

* set never_frosh on terminals since the per-row flush notifications aren't used
* don't store the main window size in the application's preferences when full-screen mode is started
* don't adjust the window visibility settings in the application's preferences when closing a window because the application is exiting
* in the mouse-click handling, add logic to screen out events that are outside the terminal bounds (i.e. on the title bar)