### PR TITLE
Always redraw the space after the equippy character in display_inven(…

### DIFF
--- a/src/object1.c
+++ b/src/object1.c
@@ -1889,16 +1889,10 @@ void display_inven(void)
         Term_putstr(0, i, 3, attr, tmp_val);
 
         /* Display the symbol */
+        Term_putch(3, i, object_attr(o_ptr), object_char(o_ptr));
         if (use_bigtile)
         {
-            Term_putstr(3, i, 1, object_attr(o_ptr),
-                format("%c", object_char(o_ptr)));
-            Term_putstr(4, i, 1, 255, format("%c", 255));
-        }
-        else
-        {
-            Term_putstr(3, i, 1, object_attr(o_ptr),
-                format("%c", object_char(o_ptr)));
+            Term_putch(4, i, 255, -1);
         }
 
         /* Obtain an item description */
@@ -1911,6 +1905,7 @@ void display_inven(void)
         attr = tval_to_attr[o_ptr->tval % N_ELEMENTS(tval_to_attr)];
 
         /* Display the entry itself */
+        Term_putch(offset - 1, i, attr, ' ');
         Term_putstr(offset, i, n, attr, o_name);
 
         /* Erase the rest of the line */
@@ -1989,16 +1984,16 @@ void display_equip(void)
         Term_putstr(0, i - INVEN_WIELD, 3, attr, tmp_val);
 
         /* Display the symbol */
+        if (!use_graphics && !o_ptr->tval) {
+            /* object_attr() for an empty slot gives '\0'.  Use ' ' instead. */
+            Term_putch(3, i - INVEN_WIELD, attr, ' ');
+        } else {
+            Term_putch(3, i - INVEN_WIELD, object_attr(o_ptr),
+                object_char(o_ptr));
+        }
         if (use_bigtile)
         {
-            Term_putstr(3, i - INVEN_WIELD, 1, object_attr(o_ptr),
-                format("%c", object_char(o_ptr)));
-            Term_putstr(4, i - INVEN_WIELD, 1, 255, format("%c", 255));
-        }
-        else
-        {
-            Term_putstr(3, i - INVEN_WIELD, 1, object_attr(o_ptr),
-                format("%c", object_char(o_ptr)));
+            Term_putch(4, i - INVEN_WIELD, 255, -1);
         }
 
         /* Obtain an item description */
@@ -2018,6 +2013,7 @@ void display_equip(void)
         attr = tval_to_attr[o_ptr->tval % N_ELEMENTS(tval_to_attr)];
 
         /* Display the entry itself */
+        Term_putch(offset - 1, i - INVEN_WIELD, attr, ' ');
         Term_putstr(offset, i - INVEN_WIELD, n, attr, o_name);
 
         /* Erase the rest of the line */


### PR DESCRIPTION
…) and display_equip() to handle transitions back and forth from ASCII graphics mode to tiles with use_bigtile on.  For the same reason, add special handling for the equippy character for unequipped item slots.