### PR TITLE
OS X: don't render the foreground tile if it's the same as the background

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2724,13 +2724,20 @@ static void Term_xtra_cocoa_fresh(AngbandContext* angbandContext)
                                 terrainRect,
                                 destinationRect,
                                 NSCompositeCopy);
-                            draw_image_tile(
-                                nsContext,
-                                ctx,
-                                pict_image,
-                                sourceRect,
-                                destinationRect,
-                                NSCompositeSourceOver);
+                            /*
+                             * Skip drawing the foreground if it is the same
+                             * as the background.
+                             */
+                            if (sourceRect.origin.x != terrainRect.origin.x ||
+                                    sourceRect.origin.y != terrainRect.origin.y) {
+                                draw_image_tile(
+                                    nsContext,
+                                    ctx,
+                                    pict_image,
+                                    sourceRect,
+                                    destinationRect,
+                                    NSCompositeSourceOver);
+                            }
                         } else {
                             draw_image_tile(
                                 nsContext,


### PR DESCRIPTION
In other words, it's a small optimization for rendering speed.