### PR TITLE
OS X: cleanup code

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -46,7 +46,6 @@
 #include <Cocoa/Cocoa.h>
 #include <Carbon/Carbon.h> // For keycodes
 
-static NSSize const AngbandScaleIdentity = {1.0, 1.0};
 static NSString * const AngbandDirectoryNameLib = @"lib";
 ////static NSString * const AngbandDirectoryNameBase = @"Angband";
 

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -62,17 +62,6 @@ static NSInteger const AngbandCommandMenuItemTagBase = 2000;
 # define USE_LIVE_RESIZE_CACHE 0
 #endif
 
-/*
- * Support the improved game command handling
- */
-////#include "textui.h"
-////static game_command cmd = { CMD_NULL, 0 };
-
-
-/* Our command-fetching function */
-////static errr cocoa_get_cmd(cmd_context context, bool wait);
-
-
 /* Application defined event numbers */
 enum
 {
@@ -1329,9 +1318,12 @@ static void create_user_dir(void)
 + (void)beginGame
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    
-    //set the command hook
-////    cmd_get_hook = cocoa_get_cmd;
+
+    /* Used by Angband but not by Sil. */
+#if 0
+    /* Set the command hook */
+    cmd_get_hook = textui_get_cmd;
+#endif
     
     /* Hooks in some "z-util.c" hooks */
     plog_aux = hook_plog;
@@ -3733,47 +3725,6 @@ static void init_windows(void)
     /* Activate the primary term */
     Term_activate(primary);
 }
-
-
-/*
- *    Run the event loop and return a gameplay status to init_angband
- */
-
-#if 0 ////
-
-static errr get_cmd_init(void)
-{     
-    if (cmd.command == CMD_NULL)
-    {
-        /* Prompt the user */ 
-        prt("[Choose 'New' or 'Open' from the 'File' menu]", 23, 17);
-        Term_fresh();
-        
-        while (cmd.command == CMD_NULL) {
-            NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-            NSEvent *event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantFuture] inMode:NSDefaultRunLoopMode dequeue:YES];
-            if (event) [NSApp sendEvent:event];
-            [pool drain];        
-        }
-    }
-    
-    /* Push the command to the game. */
-    cmd_insert_s(&cmd);
-    
-    return 0; 
-} 
-
-
-/* Return a command */
-static errr cocoa_get_cmd(cmd_context context, bool wait)
-{
-    if (context == CMD_INIT) 
-        return get_cmd_init();
-    else 
-        return textui_get_cmd(context, wait);
-}
-
-#endif ////
 
 
 //// Sil-y: begin inserted block

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3261,6 +3261,7 @@ static errr Term_text_cocoa(int x, int y, int n, byte_hack a, const char *cp)
     return (0);
 }
 
+#if 0
 /* From the Linux mbstowcs(3) man page:
  *   If dest is NULL, n is ignored, and the conversion  proceeds  as  above,
  *   except  that  the converted wide characters are not written out to mem‐
@@ -3309,6 +3310,7 @@ static size_t Term_mbcs_cocoa(wchar_t *dest, const char *src, int n)
     }
     return count;
 }
+#endif
 
 /**
  * Determine if the big tile mode (each tile is 2 grids in width) should be
@@ -3403,7 +3405,7 @@ static term *term_data_link(int i)
     newterm->bigcurs_hook = Term_bigcurs_cocoa;
     newterm->text_hook = Term_text_cocoa;
     newterm->pict_hook = Term_pict_cocoa;
-    ////newterm->mbcs_hook = Term_mbcs_cocoa;
+    /* newterm->mbcs_hook = Term_mbcs_cocoa; */
     
     /* Global pointer */
     angband_term[i] = newterm;

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4349,7 +4349,6 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
 /*** Main program ***/
 
 @interface AngbandAppDelegate : NSObject {
-    IBOutlet NSMenu *terminalsMenu;
     NSMenu *_commandMenu;
     NSDictionary *_commandMenuTagMap;
 }

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1176,9 +1176,18 @@ static int compare_advances(const void *ap, const void *bp)
     if( !libExists || !isDirectory )
     {
         NSLog( @"[%@ %@]: can't find %@/ in bundle: isDirectory: %d libExists: %d", NSStringFromClass( [self class] ), NSStringFromSelector( _cmd ), AngbandDirectoryNameLib, isDirectory, libExists );
-        NSRunAlertPanel( @"Missing Resources", @"Sil was unable to find the 'lib' folder, which should be in Sil.app/Contents/Resources, so must quit. Please report a bug on the Angband forums.", @"Quit", nil, nil );
 
-        exit( 0 );
+        NSAlert *alert = [[NSAlert alloc] init];
+        /*
+         * Note that NSCriticalAlertStyle was deprecated in 10.10.  The
+         * replacement is NSAlertStyleCritical.
+         */
+        alert.alertStyle = NSCriticalAlertStyle;
+        alert.messageText = @"MissingResources";
+        alert.informativeText = @"Sil was unable to find the 'lib' folder, which should be in Sil.app/Contents/Resources, so must quit. Please report a bug on the Angband forums.";
+        [alert addButtonWithTitle:@"Quit"];
+        [alert runModal];
+        exit(0);
     }
 
     return bundleLibPath;
@@ -4207,7 +4216,11 @@ static void hook_plog(const char * str)
     if (str)
     {
         NSString *string = [NSString stringWithCString:str encoding:NSMacOSRomanStringEncoding];
-        NSRunAlertPanel(@"Danger Will Robinson", @"%@", @"OK", nil, nil, string);
+        NSAlert *alert = [[NSAlert alloc] init];
+
+        alert.messageText = @"Danger Will Robinson";
+        alert.informativeText = string;
+        [alert runModal];
     }
 }
 

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4371,6 +4371,12 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
     [panel orderFront:self];
 }
 
+/**
+ * Implement NSObject's changeFont() method to receive a notification about the
+ * changed font.  Note that, as of 10.14, changeFont() is deprecated in
+ * NSObject - it will be removed at some point and the application delegate
+ * will have to be declared as implementing the NSFontChanging protocol.
+ */
 - (void)changeFont:(id)sender
 {
     int mainTerm;
@@ -4449,6 +4455,13 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
     record_current_savefile();
 }
 
+/**
+ * Implement NSObject's validateMenuItem() method to override enabling or
+ * disabling a menu item.  Note that, as of 10.14, validateMenuItem() is
+ * deprecated in NSObject - it will be removed at some point and the
+ * application delegate will have to be declared as implementing the
+ * NSMenuItemValidation protocol.
+ */
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
 {
     SEL sel = [menuItem action];

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -630,7 +630,7 @@ static void hook_quit(const char * str);
 static void load_prefs(void);
 static void load_sounds(void);
 static void init_windows(void);
-static void open_game(void); ////half
+static BOOL open_game(void); ////half
 static void open_tutorial(void); ////half
 static void handle_open_when_ready(void);
 static void play_sound(int event);
@@ -3728,10 +3728,8 @@ static void init_windows(void)
 
 
 //// Sil-y: begin inserted block
-//// Sil-y: the code of this function open_game() is simply copied from
-////        openGame, as I couldn't work out how to call openGame from within beginGame
 
-static void open_game(void)
+static BOOL open_game(void)
 {
     NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
     BOOL selectedSomething = NO;
@@ -3782,6 +3780,8 @@ static void open_game(void)
     }
     
     [pool drain];
+
+    return selectedSomething;
 }
 
 /*
@@ -4418,57 +4418,9 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
 
 - (IBAction)openGame:sender
 {
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-    BOOL selectedSomething = NO;
-    int panelResult;
-    char parsedPath[1024] = "";
-
-    /* Get where we think the save files are */
-    path_parse(parsedPath, sizeof(parsedPath), ANGBAND_DIR_SAVE);
-    NSURL *startingDirectoryURL =
-        [NSURL fileURLWithPath:[NSString stringWithCString:parsedPath encoding:NSASCIIStringEncoding]
-            isDirectory:YES];
-
-    /* Get what we think the default save file name is. Deafult to the empty string. */
-    NSString *savefileName = [[NSUserDefaults angbandDefaults] stringForKey:@"SaveFile"];
-    if (! savefileName) savefileName = @"";
-
-    /* Set up an open panel */
-    NSOpenPanel* panel = [NSOpenPanel openPanel];
-    [panel setCanChooseFiles:YES];
-    [panel setCanChooseDirectories:NO];
-    [panel setResolvesAliases:YES];
-    [panel setAllowsMultipleSelection:YES];
-    [panel setTreatsFilePackagesAsDirectories:YES];
-    [panel setDirectoryURL:startingDirectoryURL];
-    [panel setNameFieldStringValue:savefileName];
-
-    /* Run it */
-    panelResult = [panel runModal];
-    if (panelResult == NSOKButton)
-    {
-        NSArray* filenames = [panel filenames];
-        if ([filenames count] > 0)
-        {
-            selectedSomething = [[filenames objectAtIndex:0] getFileSystemRepresentation:savefile maxLength:sizeof savefile];
-        }
-    }
-    
-    if (selectedSomething)
-    {
-        
-        /* Remember this so we can select it by default next time */
-        record_current_savefile();
-        
-        /* Game is in progress */
-        game_in_progress = TRUE;
-        ////cmd.command = CMD_LOADFILE;
-        
+    if (open_game()) {
         Term_keypress(ESCAPE); //// half: needed to break out of the text-based start menu
-
     }
-
-    [pool drain];
 }
 
 - (IBAction)saveGame:sender

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -646,8 +646,11 @@ static void open_tutorial(void); ////half
 static void handle_open_when_ready(void);
 static void play_sound(int event);
 static BOOL check_events(int wait);
-////static void cocoa_file_open_hook(const char *path, file_type ftype);
+/* Used by Angband but not by Sil. */
+#if 0
+static void cocoa_file_open_hook(const char *path, file_type ftype);
 static bool cocoa_get_file(const char *suggested_name, char *path, size_t len);
+#endif
 static BOOL send_event(NSEvent *event);
 static void record_current_savefile(void);
 
@@ -1334,11 +1337,14 @@ static void create_user_dir(void)
     plog_aux = hook_plog;
     quit_aux = hook_quit;
     
-	/* Hook in to the file_open routine */
-////	file_open_hook = cocoa_file_open_hook;
+    /* Used by Angband but not by Sil. */
+#if 0
+    /* Hook in to the file_open routine */
+    file_open_hook = cocoa_file_open_hook;
 
     /* Hook into file saving dialogue routine */
-////half    get_file = cocoa_get_file;
+    get_file = cocoa_get_file;
+#endif
 
     // initialize file paths
     [self prepareFilePathsAndDirectories];
@@ -4264,7 +4270,8 @@ static void hook_quit(const char * str)
     exit(0);
 }
 
-#if 0 ////
+/* Used by Angband but by Sil.  Comment them out. */
+#if 0
 
 /* Set HFS file type and creator codes on a path */
 static void cocoa_file_open_hook(const char *path, file_type ftype)
@@ -4307,7 +4314,7 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
     return FALSE;
 }
 
-#endif ////
+#endif
 
 //// Sil-y: begin inserted block
 

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3918,6 +3918,8 @@ static BOOL contains_angband_view(NSView *view)
  */
 static void AngbandHandleEventMouseDown( NSEvent *event )
 {
+	/* Sil doesn't use mouse events; Angband does.  Comment it out. */
+#if 0
 	AngbandContext *angbandContext = [[[event window] contentView] angbandContext];
 	AngbandContext *mainAngbandContext = angband_term[0]->data;
 
@@ -3962,9 +3964,10 @@ static void AngbandHandleEventMouseDown( NSEvent *event )
 			button |= (angbandModifiers & 0x0F) << 4; // encode modifiers in the button number (see Term_mousepress())
 #endif
 
-////half			Term_mousepress(x, y, button);
+			Term_mousepress(x, y, button);
 		}
 	}
+#endif
 
 	/* Pass click through to permit focus change, resize, etc. */
 	[NSApp sendEvent:event];

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -494,9 +494,6 @@ static int resize_pending_changes(struct PendingChanges* pc, int nrow)
 /* Begins an Angband game. This is the entry point for starting off. */
 + (void)beginGame;
 
-/* Ends an Angband game. */
-+ (void)endGame;
-
 /* Internal method */
 - (AngbandView *)activeView;
 
@@ -1447,16 +1444,6 @@ static void create_user_dir(void)
 		game_in_progress = FALSE;
 		[pool drain];
 	}
-}
-
-+ (void)endGame
-{    
-    /* Hack -- Forget messages */
-    msg_flag = FALSE;
-    
-    p_ptr->playing = FALSE;
-    p_ptr->leaving = TRUE;
-    quit_when_ready = TRUE;
 }
 
 

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1810,16 +1810,7 @@ static NSMenuItem *superitem(NSMenuItem *self)
         return;
     }
 
-    int termIndex = 0;
-
-    for( termIndex = 0; termIndex < ANGBAND_TERM_MAX; termIndex++ )
-    {
-        if( angband_term[termIndex] == self->terminal )
-        {
-            break;
-        }
-    }
-
+    int termIndex = [self terminalIndex];
     NSMenuItem *item = [[[NSApplication sharedApplication] windowsMenu] itemWithTag: AngbandWindowMenuItemTagBase + termIndex];
     [item setState: NSOnState];
 
@@ -1838,16 +1829,7 @@ static NSMenuItem *superitem(NSMenuItem *self)
         return;
     }
 
-    int termIndex = 0;
-
-    for( termIndex = 0; termIndex < ANGBAND_TERM_MAX; termIndex++ )
-    {
-        if( angband_term[termIndex] == self->terminal )
-        {
-            break;
-        }
-    }
-
+    int termIndex = [self terminalIndex];
     NSMenuItem *item = [[[NSApplication sharedApplication] windowsMenu] itemWithTag: AngbandWindowMenuItemTagBase + termIndex];
     [item setState: NSOffState];
 }


### PR DESCRIPTION
Gets rid of some compiler warnings, removes some repeated code, handles a deprecation from Apple, and add comments about deprecations that'll have to be taken care of at some point (not doing so now to keep the status quo for backwards compatibility).