### PR TITLE
Add padding character for bigtile mode to the symbol in the monster knowledge list

### DIFF
--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -10658,6 +10658,13 @@ static void display_monster_list(int col, int row, int per_page,
 
         /* Display symbol */
         Term_putch(68, row + i, r_ptr->x_attr, r_ptr->x_char);
+        if (use_bigtile)
+        {
+            if ((byte)(r_ptr->x_attr) & 0x80)
+                Term_putch(69, row + i, 255, -1);
+            else
+                Term_putch(69, row + i, 0, ' ');
+        }
 
         /* Display kills */
         if (r_ptr->flags1 & (RF1_UNIQUE))


### PR DESCRIPTION
Without it, the right half of the tile for a monster wasn't cleared on OS X for the rows beyond what's in the current category (i.e. going from a category with more monsters to one with fewer left clearing artifacts).  I didn't see the same problem on Linux, but I didn't check if it was using bigtile mode.