### PR TITLE
Resolved crash when clicking on a Sil-Q X11 window

### DIFF
--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -1710,7 +1710,8 @@ static void paste_x11_send(XSelectionRequestEvent* rq)
         target_list[1] = XA_STRING;
 
         XChangeProperty(DPY, rq->requestor, rq->property, rq->target,
-            (8 * sizeof(target_list[0])), PropModeReplace,
+            32,
+            PropModeReplace,
             (unsigned char*)target_list,
             (sizeof(target_list) / sizeof(target_list[0])));
 


### PR DESCRIPTION
XChangeProperty:format specifies whether the data should be viewed as 8,16,32 bit.
The data in this case is an Atom, which is a typedef for unsigned long on x64 (64bits).
This causes a crash, since 64 bit is not allowed. While this is confusing, 32 bit
should be used even though the data itself might be 64 bit.