### PR TITLE
OS X:  in the default preferences, use the keys, FontName-0 and…

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3815,9 +3815,9 @@ static void load_prefs()
     }
 
     NSDictionary *defaults = [[NSDictionary alloc] initWithObjectsAndKeys:
-                              ////half @"Menlo", @"FontName",
-                              @"Monaco", @"FontName", ////half
-                              [NSNumber numberWithFloat:12.f], @"FontSize",
+                              ////half @"Menlo", @"FontName-0",
+                              @"Monaco", @"FontName-0", ////half
+                              [NSNumber numberWithFloat:12.f], @"FontSize-0",
                               [NSNumber numberWithInt:60], AngbandFrameRateDefaultsKey,
                               [NSNumber numberWithBool:YES], AngbandSoundDefaultsKey,
                               [NSNumber numberWithInt:GRAPHICS_NONE], AngbandGraphicsDefaultsKey,


### PR DESCRIPTION
…FontSize-0, since those, rather than FontName and FontSize, are what are examined to get the name and size of the font for the main window.