### PR TITLE
OS X tile conversion script:  had test that was intended to be "is …

### DIFF
--- a/lib/xtra/graf/osx_bmp2png.py
+++ b/lib/xtra/graf/osx_bmp2png.py
@@ -105,7 +105,7 @@ arrout = numpy.empty((tin.height,tin.width,4), dtype='u1')
 if palette:
         parr = numpy.reshape(numpy.array(palette), (len(palette) // 3, 3))
         arrout[:,:,0:3] = parr[arrin]
-        if trind:
+        if trind is not None:
                 arrout[:,:,3] = numpy.where(
                         numpy.logical_and(arrt, arrin == trind),
                         numpy.zeros((tin.height, tin.width), dtype='u1'),


### PR DESCRIPTION
…not None" but was instead "is nonzero".  That would break conversion of a tile set with a palette if the color table index for pixels to be treated as transparent was zero.  The change does not effect the result for the current version of Microchasm's tiles.