### PR TITLE
fix build guide/makefile/.gitattribute for windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *  text=auto
+src/unix2dos  text eol=lf
+src/unix2doslib  text eol=lf

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ this file for advice on your specific system.
 
    Download the free Cygwin compiler. It provides a shell interface very
    similar to a normal Unix/Linux shell with many useful tools. Install it
-   and start the Cygwin terminal.
+   and start the Cygwin terminal. Make sure to get the 32 bit version.
 
    Note you will have to ensure "make" and the mingw C compiler are installed
    as they may not be included in your Cygwin default installation.


### PR DESCRIPTION
I had some issues trying to build Sil-Q on Windows using the instructions found in README.md.

With some help I was able to narrow down my issues to the following:

- I was using the 64bit version of Cygwin rather than the 32bit version.
- the unix2dos and unix2doslib files were checked out with Windows line endings instead of Linux line endings.
- the Makefile had a few specific parameters which made the build overall not work. 

This commit fixes these issues.

Especially re: the last issue, I can understand if these parameters serve some purpose unknown to me. I am simply sharing what made the build work for me.