### PR TITLE
macOS: round width to nearest (unless zero) rather than up

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1493,10 +1493,15 @@ static int compare_advances(const void *ap, const void *bp)
     }
 
     /*
-     * Record the tile size.  Round both values up to have tile boundaries
-     * match pixel boundaries.
+     * Record the tile size.  Round the values (height rounded up; width to
+     * nearest unless that would be zero) to have tile boundaries match pixel
+     * boundaries.
      */
-    self->_tileSize.width = ceil(medianAdvance);
+    if (medianAdvance < 1.0) {
+        self->_tileSize.width = 1.0;
+    } else {
+        self->_tileSize.width = floor(medianAdvance + 0.5);
+    }
     self->_tileSize.height = ceil(self.fontAscender - self.fontDescender);
 
     /*


### PR DESCRIPTION
That gives a somewhat more compact display with the default font for the main window (7 vs 8 pixels per column) and subwindows except for WINDOW_MONSTER (5 vs 6 pixels per column).  That also can be closer to the appearance of the 1.4 interface which didn't round the width.  MicroChasm's tiles still look okay though, with this change and the default font, they'll be scaled to 14 x 15 rather than 16 x 15 for display in the main window.