### PR TITLE
fixed incorrect dialogue in Oath ability

### DIFF
--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -992,8 +992,8 @@ char* oath_name[] = {
 
 char* oath_desc1[] = {
     "Nothing",
-    "to leave Angband as you came, grim and silent",
     "to leave Angband without shedding blood of Man or Elf",
+    "to leave Angband as you came, grim and silent",
     "that none will daunt you from facing Morgoth forthwith",
 };
 


### PR DESCRIPTION
Dialogue after selecting oath ability currently has nonsensical pairing: 
"grim and silent" paired with "attack men or elves"
"without shedding blood of men or elves" with sing.

I fixed this to the correct pairing, matching with the flags in xtra1.c to ensure the correct option was moved.

A very minor fix, but an immersion-breaking bug nonetheless.