### PR TITLE
Mac: only allow saving from the menu bar when the core game is waiting…

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4959,10 +4959,6 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
     {
         return ! game_in_progress;
     }
-    else if (sel == @selector(saveGame:))   //// half
-    {                                       //// half
-        return (turn > 0);                  //// half
-    }                                       //// half
     else if (sel == @selector(setRefreshRate:) &&
              [[menuItem parentItem] tag] == 150)
     {
@@ -4976,10 +4972,15 @@ extern void fsetfileinfo(cptr pathname, u32b fcreator, u32b ftype)
         [menuItem setState: (tag == requestedGraphicsMode)];
         return YES;
     }
-    else if( sel == @selector(sendAngbandCommand:) )
+    else if( sel == @selector(sendAngbandCommand:) ||
+		sel == @selector(saveGame:) )
     {
-        /* we only want to be able to send commands during an active game */
-        return !!game_in_progress;
+        /*
+	 * we only want to be able to send commands during an active game
+	 * after the birth screens when the core is waiting for a player
+	 * command
+	 */
+        return !!game_in_progress && character_generated && inkey_flag;
     }
     else return YES;
 }


### PR DESCRIPTION
… for a player command.  That's in line with the Windows front end and prevents saving while at the "You die. [more]" prompt or while at the menu to start the game or enter the tutorial.

It also better aligns the Mac front end with the one in Vanilla Angband after https://github.com/angband/angband/pull/5423 .