### PR TITLE
fix: show "Mortal wound" if a player's cuts are >= 100 (fixes #118)

### DIFF
--- a/src/xtra1.c
+++ b/src/xtra1.c
@@ -678,7 +678,7 @@ static void prt_cut(void)
 
     put_str("            ", ROW_CUT - 1, COL_CUT);
 
-    if (c > 100)
+    if (c >= 100)
     {
         c_put_str(TERM_RED, "Mortal wound", r, COL_CUT);
     }


### PR DESCRIPTION
This fixes #118.