### PR TITLE
fix: docs for lightning chance for cross-shaped rooms (fixes #116)

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -2138,7 +2138,17 @@ static bool build_type2(int y0, int x0)
 
     int light = FALSE;
 
-    /* Occasional light - always at level 1 through to never at Morgoth's level
+    /* Occasional light.
+     * Almost always (95%) at level 1 through to never (0%) at Morgoth's level.
+     *
+     * Dungeon level (depth)   Chance
+     * ------------------------------
+     *   1  -   50ft             95%
+     *   2  -  100ft             90%
+     *   3  -  150ft             85%
+     *  ...                      ...
+     *  19  -  950ft              5%
+     *  20  - 1000ft              0%
      */
     if (p_ptr->depth < dieroll(MORGOTH_DEPTH))
         light = TRUE;


### PR DESCRIPTION
Fixes https://github.com/sil-quirk/sil-q/issues/116.

To fix the issue, I decided for option 1 in the thread above = "Could change the comment". 

The relevant code snippet from `build_type2()` in `src/generate.c` is:

```c
    if (p_ptr->depth < dieroll(MORGOTH_DEPTH))
        light = TRUE;
```

where `MORGOTH_DEPTH` level is `20` and `dieroll(M)` generates a random int in range `[1...M]` (i.e., including start and end of range).

Reasoning to update the code comment to match the code above, rather than vice versa:

- For the gameplay, it makes sense to have a 0% light chance in Morgoth's throne room (level 20). He's the first Dark Lord after all!
- It doesn't really matter whether level 1 has a 95% vs. 100% light chance, neither with regards to Tolkien lore in Sil-Q nor for the gameplay mechanics.
- Unless we want to make the code above a bit more complex (e.g., special casing level 1 or level 20), we have to choose between (1) the current approach of `(p_ptr->depth < dieroll(MORGOTH_DEPTH)`, which results in 95% light chance at level 1 and 0% at level 20 vs. (2) the alternative approach mentioned in #116 of `(p_ptr->depth < dieroll(MORGOTH_DEPTH + 1)`, which results in 100% chance at level 1 and 5% chance at level 20. Because of what I said in the previous bullet item, (1) makes more sense to me than (2). Sure, we could special-case with an if-condition, but why?

