### PR TITLE
fix: prevent signed integer overflow in update_mon()

### DIFF
--- a/src/monster2.c
+++ b/src/monster2.c
@@ -1659,7 +1659,7 @@ void update_mon(int m_idx, bool full)
     for (int i = 0; i < RAND_DEG; i++)
     {
         tmp_rand_state[i] = Rand_state[i];
-        Rand_state[i] = playerturn * i * 15485863; // large prime
+        Rand_state[i] = (u32b)playerturn * i * 15485863UL; // large prime
     }
 
     listen(m_ptr);


### PR DESCRIPTION
Discovered while running a debug build with UBSAN enabled. This overflow happens in the following RNG-related code:

```c
    for (int i = 0; i < RAND_DEG; i++)
    {
        tmp_rand_state[i] = Rand_state[i];
        Rand_state[i] = playerturn * i * 15485863; // <=== this line
    }

```

I have a savefile, if needed, where this is consistently triggered on player turn 3 for a fresh character.
