### PR TITLE
feat: add "minimum depth" to game HUD

### DIFF
--- a/lib/docs/CHANGELOG.md
+++ b/lib/docs/CHANGELOG.md
@@ -104,6 +104,14 @@ Added:
   "blank" color to denote color transparency, because the BMP format does not
   support transparency natively. The graphics rendering backends now
   automatically detect the transparency color via pixel (0,0).
+- Added a "minimum depth" field to the game HUD (partially fixes #82)
+  ([#132](https://github.com/sil-quirk/sil-q/pull/132)). To make room for this
+  change, the "current depth" field was moved from the last row in the bottom
+  right to the second-to-last row in the bottom left. The new "minimum depth"
+  field is placed in grey color in the last row, underneath "current depth".
+  Other bottom-row HUD fields like "Confused" and "Stun" where shifted to the
+  right. See [minimum depth
+  screenshot](https://github.com/sil-quirk/sil-q/pull/132#issue-3830778399).
 
 Changed:
 

--- a/src/cmd2.c
+++ b/src/cmd2.c
@@ -11,8 +11,13 @@
 #include "angband.h"
 
 /*
- * Determines the shallowest a player is allowed to go.
- * As time goes on, they are forced deeper and deeper.
+ * Determines the shallowest depth a player is allowed to go. For example, if
+ * min depth is 200 ft, a player may ascend from 300 ft to 200 ft, but not to
+ * 150 ft or higher.
+ *
+ * As time goes on, they are forced deeper and deeper into the dungeon. This
+ * also takes away the option of "staircase scumming", by which the player can
+ * reset/regenerate dungeon levels (e.g., for escaping a group of monsters).
  */
 int min_depth(void)
 {

--- a/src/defines.h
+++ b/src/defines.h
@@ -729,31 +729,34 @@
 #define COL_STEALTH 0 /* <stealth> */
 
 #define ROW_HUNGRY (Term->hgt - 1)
-#define COL_HUNGRY 0 /* "Starving" "Weak" / "Hungry" / "Full" */
+#define COL_HUNGRY 13 /* "Starving" "Weak" / "Hungry" / "Full" */
 
 #define ROW_BLIND (Term->hgt - 1)
-#define COL_BLIND 9 /* "Blind" */
+#define COL_BLIND 22 /* "Blind" */
 
 #define ROW_CONFUSED (Term->hgt - 1)
-#define COL_CONFUSED 15 /* "Confused" */
+#define COL_CONFUSED 28 /* "Confused" */
 
 #define ROW_STUN (Term->hgt - 1)
-#define COL_STUN 24 /* <stun> */
+#define COL_STUN 37 /* "Knocked out" / "Heavy stun" / "Stun" */
 
 #define ROW_AFRAID (Term->hgt - 1)
-#define COL_AFRAID 36 /* "Afraid" */
+#define COL_AFRAID 49 /* "Afraid" */
 
 #define ROW_STATE (Term->hgt - 1)
-#define COL_STATE 43 /* <state> */
+#define COL_STATE 56 /* <state> - e.g. "Stealth", "Entranced!", "Smithing" */
 
 #define ROW_SPEED (Term->hgt - 1)
-#define COL_SPEED 56 /* "Slow" or "Fast" */
+#define COL_SPEED 67 /* "Slow" or "Fast" */
 
 #define ROW_TERRAIN (Term->hgt - 1)
-#define COL_TERRAIN 61 /* "Web" or "Pit" or "Sunlight" */
+#define COL_TERRAIN 72 /* "Web" or "Pit" or "Sunlight" */
 
-#define ROW_DEPTH (Term->hgt - 1)
-#define COL_DEPTH 72 /* "Lev NNN" / "NNNN ft" */
+#define ROW_DEPTH (Term->hgt - 2)
+#define COL_DEPTH 0 /* "NNNN ft" (current depth) right-aligned in sidebar */
+
+#define ROW_MIN_DEPTH (Term->hgt - 1)
+#define COL_MIN_DEPTH 0 /* "min NNNN ft" right-aligned in sidebar */
 
 /*** General index values ***/
 

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -2471,13 +2471,17 @@ static void process_player(void)
         }
     }
 
+    // Increment turn counter.
     playerturn++;
 
+    // Update minimum depth.
     depth_counter_increment = 85 - (playerturn / 850);
     depth_counter_increment += 3 * (p_ptr->depth - min_depth());
-
+    int old_min_depth = min_depth();
     min_depth_counter
         += depth_counter_increment > 0 ? depth_counter_increment : 0;
+    if (min_depth() != old_min_depth)
+        p_ptr->redraw |= (PR_DEPTH);
 
     /* Window stuff */
 

--- a/src/xtra1.c
+++ b/src/xtra1.c
@@ -530,20 +530,27 @@ static void prt_song(void)
 }
 
 /*
- * Prints depth in stat area
+ * Prints current depth and minimum depth in the left-hand sidebar.
+ *
+ * The two values are rendered on the bottom two rows of the sidebar
+ * (anchored to the terminal bottom), right-aligned within the 12-char
+ * sidebar width. Min depth is muted to distinguish it from current depth.
  */
 static void prt_depth(void)
 {
-    char depths[32];
+    char depths[16];
+    char min_depths[16];
     s16b attr = TERM_WHITE;
 
     if (!p_ptr->depth)
     {
         my_strcpy(depths, "Surface", sizeof(depths));
+        my_strcpy(min_depths, "", sizeof(min_depths));
     }
     else
     {
         strnfmt(depths, sizeof(depths), "%d ft", p_ptr->depth * 50);
+        strnfmt(min_depths, sizeof(min_depths), "min %d ft", min_depth() * 50);
     }
 
     /* Get color of level based on feeling  -JSV- */
@@ -573,8 +580,11 @@ static void prt_depth(void)
             attr = TERM_BLUE;
     }
 
-    /* Right-Adjust the "depth", and clear old values */
-    c_prt(attr, format("%7s", depths), ROW_DEPTH, COL_DEPTH);
+    // Right-aligned within the 12-char sidebar. `c_put_str` avoids clearing the
+    // bottom row's status-effect area to the right.
+    c_put_str(attr, format("%12s", depths), ROW_DEPTH, COL_DEPTH);
+    c_put_str(
+        TERM_L_DARK, format("%12s", min_depths), ROW_MIN_DEPTH, COL_MIN_DEPTH);
 }
 
 /*
@@ -908,19 +918,19 @@ static void prt_stun(void)
 
     if (s > 100)
     {
-        c_put_str(TERM_RED, "Knocked out ", ROW_STUN, COL_STUN);
+        c_put_str(TERM_RED, "Knocked out", ROW_STUN, COL_STUN);
     }
     else if (s > 50)
     {
-        c_put_str(TERM_ORANGE, "Heavy stun  ", ROW_STUN, COL_STUN);
+        c_put_str(TERM_ORANGE, "Heavy stun ", ROW_STUN, COL_STUN);
     }
     else if (s)
     {
-        c_put_str(TERM_ORANGE, "Stun        ", ROW_STUN, COL_STUN);
+        c_put_str(TERM_ORANGE, "Stun       ", ROW_STUN, COL_STUN);
     }
     else
     {
-        put_str("            ", ROW_STUN, COL_STUN);
+        put_str("           ", ROW_STUN, COL_STUN);
     }
 }
 


### PR DESCRIPTION
Adds a "minimum depth" field to the HUD, matching the mockup by @sil-quick in comment https://github.com/sil-quirk/sil-q/pull/132#issuecomment-3802127709.

Other HUD fields had to be moved for this to make room for the added field:

1. `Current depth` is moved from bottom right (last row) to the bottom left (second-to-last row).
2. `Minimum depth` is placed in grey color underneath the current depth.
3. Other bottom-row fields (e.g., hunger, stun, afraid) where shifted by 13 characters to the right.

----

HUD before this change (note row 24):

```
===================================================================================== 
  0|You hit the Orc scout! The Orc scout misses you. You hit the Orc scout! -more-  |
  1|CharName    |                                                                   |
  2|            |                                                                   |
  3|Str        3|                                                                   |
  4|Dex        3|                                                                   |
  5|Con        7|                                                                   |
  6|Gra        3|                                                                   |
  7|            |                                                                   |
  8|Exp   50,000|                                                                   |
  9|            |                                                                   |
 10|Health 71:71|                                                                   |
 11|Voice  18:34|                             Dungeon Map                           |
 12|            |                                                                   |
 13|   (+12,2d8)|                                                                   |
 14|    (+3,1d8)|                                                                   |
 15|   [+9,6-18]|                                                                   |
 16|            |                                                                   |
 17|  *——————-  |                                                                   |
 18|Confident -3|                                                                   |
 19|Bleeding 2  |                                                                   |
 20|Poisoned 4  | <-- Bleeding defaults to here, moves up when Poisoned             |
 21|Delvings    |                                                                   |
 22|            |                                                                   |
 23|            |                                                                   |
 24|Starving Blind Confused Heavy stun  Afraid Stealth      Slow  Sunlight  1000 ft |
=====================================================================================
    01234567890123456789012345678901234567890123456789012345678901234567890123456789 (80 cols)
    |         |         |         |         |         |         |         |
idx 0         10        20        30        40        50        60        70
```


HUD after this change (note rows 23 and 24):

```
=====================================================================================
  0|You hit the Orc scout! The Orc scout misses you. You hit the Orc scout! -more-  |
  1|CharName    |                                                                   |
  2|            |                                                                   |
  3|Str        3|                                                                   |
  4|Dex        3|                                                                   |
  5|Con        7|                                                                   |
  6|Gra        3|                                                                   |
  7|            |                                                                   |
  8|Exp   50,000|                                                                   |
  9|            |                                                                   |
 10|Health 71:71|                                                                   |
 11|Voice  18:34|                             Dungeon Map                           |
 12|            |                                                                   |
 13|   (+12,2d8)|                                                                   |
 14|    (+3,1d8)|                                                                   |
 15|   [+9,6-18]|                                                                   |
 16|            |                                                                   |
 17|  *——————-  |                                                                   |
 18|Confident -3|                                                                   |
 19|Bleeding 2  |                                                                   |
 20|Poisoned 4  | <-- Bleeding defaults to here, moves up when Poisoned             |
 21|Delvings    |                                                                   |
 22|            |                                                                   |
 23|     1000 ft|                                                                   |
 24| min 1000 ft|Starving Blind Confused Heavy stun  Afraid Stealth    Slow Sunlight|
=====================================================================================
    01234567890123456789012345678901234567890123456789012345678901234567890123456789 (80 cols)
    |         |         |         |         |         |         |         |
idx 0         10        20        30        40        50        60        70
```

----

Screenshot (see bottom left corner):

<img width="1583" height="1186" alt="Screenshot_20260511_101930" src="https://github.com/user-attachments/assets/d57796db-2e89-4404-b767-924cf0f342c2" />

---

**ORIGINAL, NOW OUTDATED DESCRIPTION BELOW**

Implements two feature requests from https://github.com/sil-quirk/sil-q/issues/82.

The turn counter introduces a new configuration option `show_turn_counter`, which is disabled by default. The reason to not enable it by default is that the turn counter requires a screen redraw after every turn that the player made, which could be an expensive operation when Sil-Q is run e.g. via SSH over the network on a remote server.

The min depth information is always shown and has no configuration setting.

This is how the new UI elements look in the bottom of the screen when the turn counter is enabled:

```
    100 ft (min 50 ft) turn 295
           ^^^^^^^^^^^ ^^^^^^^^
               new       new
```

and when the turn counter is not enabled:

```
    100 ft (min 50 ft)
           ^^^^^^^^^^^
               new
```

I manually verified that this change does not break savefiles:

- A Sil-Q build (latest code) prior to this PR can read newer savefiles written by a new build that includes this PR.
- A new build can read old savefiles.

Writing ("Appending to") and loading options from a 'Pref' file seem to work, too.