### PR TITLE
Always use `dun->cent_n * dun->cent_n * 10` corridor attempts in phase 2 of connect_rooms_stairs()

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -1884,17 +1884,14 @@ static bool connect_rooms_stairs(void)
     // make some random connections between rooms so long as they don't
     // intersect things
 
-    switch (p_ptr->cur_map_hgt / PANEL_HGT)
-    {
-    case 3:
-        corridor_attempts = dun->cent_n * dun->cent_n;
-    case 4:
-        corridor_attempts = dun->cent_n * dun->cent_n * 2;
-    case 5:
-        corridor_attempts = dun->cent_n * dun->cent_n * 10;
-    default:
-        corridor_attempts = dun->cent_n * dun->cent_n * 10;
-    }
+    // Originally, the code used a `switch (p_ptr->cur_map_hgt / PANEL_HGT)`
+    // statement in an attempt to determine corridor attempts. But the switch
+    // did nothing, because it was missing `break` statements (see commit
+    // fd1a5e6).
+    // In 2026, the decision was made to solidify the actual behavior rather
+    // than to risk breaking (no pun intended) the level generation code
+    // unintentionally by fixing the switch statement.
+    corridor_attempts = dun->cent_n * dun->cent_n * 10;
 
     for (i = 0; i < corridor_attempts; i++)
     {


### PR DESCRIPTION
This bug was found by running the build with `-Wextra`.

In phase 2, we make some random connections between rooms as long as they don't intersect things.

Before this change, the switch statement would always and only set corridor attempts to:

    corridor_attempts = dun->cent_n * dun->cent_n * 10;

This resulted in always returning the maximum number of corridor attempts (think: base attempts * 10) instead of setting corridor attempts depending on current dungeon level height.

The problematic code was introduced in commit 8c668cc in 2020. This means it has been around for several years, including the latest official v1.5.0 release (but was not in v1.4.2 from 2019).

Notes:

- When reviewing, please consider whether the original ("buggy") behavior is actually preferable. As I said, the old behavior has been in Sil-Q since 5 years, so maybe it should even stay as-is? If it should stay as-is (no change), then we should remove the switch statement altogether and replace it with a single assignment = the code snippet above. Otherwise, the compiler will complain about the broken switch statement, and it will confuse code maintainers.