### PR TITLE
macOS: put call to setTerm() last in the terminal initialzation hook

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1629,7 +1629,7 @@ static int compare_advances(const void *ap, const void *bp)
 
 - (void)requestRedraw
 {
-    if (! self->terminal) return;
+    if (!self->terminal || !self->terminal->mapped_flag) return;
     
     term *old = Term;
     
@@ -2742,12 +2742,6 @@ static void Term_init_cocoa(term *t)
         if (autosaveName) [window setFrameAutosaveName:autosaveName];
 
         /*
-         * Tell it about its term. Do this after we've sized it so that the
-         * sizing doesn't trigger redrawing and such.
-         */
-        [context setTerm:t];
-
-        /*
          * Only order front if it's the first term. Other terms will be ordered
          * front from AngbandUpdateWindowVisibility(). This is to work around a
          * problem where Angband aggressively tells us to initialize terms that
@@ -2758,8 +2752,11 @@ static void Term_init_cocoa(term *t)
 
         NSEnableScreenUpdates();
 
-        /* Set "mapped" flag */
-        t->mapped_flag = true;
+        /*
+         * Tell it about its term. Do this after we've sized it so that the
+         * sizing doesn't trigger redrawing and such.
+         */
+        [context setTerm:t];
     }
 }
 


### PR DESCRIPTION
Reported, in the comments on https://github.com/sil-quirk/sil-q/issues/121 , to resolve an infinite recursion at startup that leads to an out of memory condition.  Do not set mapped_flag in the terminal initialization hook since Term_activate() does that after calling the hook.  Bail out early from a redraw request if the terminal is not mapped in case the redraw happens between the end of the terminal initialization hook and when Term_activate() sets mapped_flag.