### PR TITLE
fix: memory leaks due to duplicate allocation of objects/special/flavor data without freeing first

### DIFF
--- a/src/init2.c
+++ b/src/init2.c
@@ -329,11 +329,14 @@ static errr init_info_raw(int fd, header* head)
     /* Accept the header */
     COPY(head, &test, header);
 
-    /* Allocate the "*_info" array */
-    C_MAKE(head->info_ptr, head->info_size, char);
+    if (head->info_size)
+    {
+        /* Allocate the "*_info" array */
+        C_MAKE(head->info_ptr, head->info_size, char);
 
-    /* Read the "*_info" array */
-    fd_read(fd, head->info_ptr, head->info_size);
+        /* Read the "*_info" array */
+        fd_read(fd, head->info_ptr, head->info_size);
+    }
 
     if (head->name_size)
     {
@@ -1129,10 +1132,13 @@ extern void re_init_some_things(void)
     op_ptr->window_flag[WINDOW_MONLIST] |= (PW_MONLIST);
 
     // re-initialize the objects and flavors
+    free_info(&k_head);
     if (init_k_info())
         quit("Cannot initialize objects");
+    free_info(&flavor_head);
     if (init_flavor_info())
         quit("Cannot initialize flavors");
+    free_info(&e_head);
     if (init_e_info())
         quit("Cannot initialize special items");
 }


### PR DESCRIPTION
This was detected at run-time by LeakSanitizer. It took me a surprisingly long time to pin down the problem. The fix was easy.

To reproduce:

- Build Sil-Q with ASAN/UBSAN enabled.
- Launch the game.
- Start the tutorial, then immediately quit the tutorial with `Q` (confirm with `y` and then `@`), then quit the game with `d` in the menu.
- LeakSanitizer will then report the memory leaks below.

This bug has been in Sil-Q since July 2020 (commit 8c668cce). This means it also affects the latest official release v1.5.0.

The impact of the bug was limited, I think, because the leak was triggered only when the application quit anyways (so the OS would take care of freeing up the memory).

----
<details><summary>Detailed report by LeakSanitizer</summary>
<p>

```
==241860==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 43200 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d4a4e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 5a053b2c39acdde66812d293604438f39b6f73db)
    #1 0x000000401ac4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x000000816922 in init_info_raw /home/miguno/git/sil-q/src/init2.c:273
    #3 0x000000817e20 in init_info /home/miguno/git/sil-q/src/init2.c:412
    #4 0x000000819a44 in init_k_info /home/miguno/git/sil-q/src/init2.c:693
    #5 0x00000082177b in init_angband /home/miguno/git/sil-q/src/init2.c:1678
    #6 0x00000086abaa in main /home/miguno/git/sil-q/src/main.c:558
    #7 0x7f4d49a105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #8 0x7f4d49a10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #9 0x000000400ea4 in _start (/home/miguno/git/sil-q/sil+0x400ea4) (BuildId: 7d0488101deff1638a1bda565cea22f7b08e36c4)

Direct leak of 18393 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d4a4e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 5a053b2c39acdde66812d293604438f39b6f73db)
    #1 0x000000401ac4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x00000081728c in init_info_raw /home/miguno/git/sil-q/src/init2.c:310
    #3 0x000000817e20 in init_info /home/miguno/git/sil-q/src/init2.c:412
    #4 0x000000819a44 in init_k_info /home/miguno/git/sil-q/src/init2.c:693
    #5 0x00000082177b in init_angband /home/miguno/git/sil-q/src/init2.c:1678
    #6 0x00000086abaa in main /home/miguno/git/sil-q/src/main.c:558
    #7 0x7f4d49a105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #8 0x7f4d49a10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #9 0x000000400ea4 in _start (/home/miguno/git/sil-q/sil+0x400ea4) (BuildId: 7d0488101deff1638a1bda565cea22f7b08e36c4)

Direct leak of 8700 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d4a4e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 5a053b2c39acdde66812d293604438f39b6f73db)
    #1 0x000000401ac4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x000000816922 in init_info_raw /home/miguno/git/sil-q/src/init2.c:273
    #3 0x000000817e20 in init_info /home/miguno/git/sil-q/src/init2.c:412
    #4 0x000000819e70 in init_e_info /home/miguno/git/sil-q/src/init2.c:774
    #5 0x0000008217d2 in init_angband /home/miguno/git/sil-q/src/init2.c:1693
    #6 0x00000086abaa in main /home/miguno/git/sil-q/src/main.c:558
    #7 0x7f4d49a105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #8 0x7f4d49a10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #9 0x000000400ea4 in _start (/home/miguno/git/sil-q/sil+0x400ea4) (BuildId: 7d0488101deff1638a1bda565cea22f7b08e36c4)

Direct leak of 3720 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d4a4e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 5a053b2c39acdde66812d293604438f39b6f73db)
    #1 0x000000401ac4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x000000816922 in init_info_raw /home/miguno/git/sil-q/src/init2.c:273
    #3 0x000000817e20 in init_info /home/miguno/git/sil-q/src/init2.c:412
    #4 0x00000081a766 in init_flavor_info /home/miguno/git/sil-q/src/init2.c:959
    #5 0x000000821880 in init_angband /home/miguno/git/sil-q/src/init2.c:1723
    #6 0x00000086abaa in main /home/miguno/git/sil-q/src/main.c:558
    #7 0x7f4d49a105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #8 0x7f4d49a10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #9 0x000000400ea4 in _start (/home/miguno/git/sil-q/sil+0x400ea4) (BuildId: 7d0488101deff1638a1bda565cea22f7b08e36c4)

Direct leak of 2358 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d4a4e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 5a053b2c39acdde66812d293604438f39b6f73db)
    #1 0x000000401ac4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x000000816ddb in init_info_raw /home/miguno/git/sil-q/src/init2.c:291
    #3 0x000000817e20 in init_info /home/miguno/git/sil-q/src/init2.c:412
    #4 0x000000819a44 in init_k_info /home/miguno/git/sil-q/src/init2.c:693
    #5 0x00000082177b in init_angband /home/miguno/git/sil-q/src/init2.c:1678
    #6 0x00000086abaa in main /home/miguno/git/sil-q/src/main.c:558
    #7 0x7f4d49a105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #8 0x7f4d49a10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #9 0x000000400ea4 in _start (/home/miguno/git/sil-q/sil+0x400ea4) (BuildId: 7d0488101deff1638a1bda565cea22f7b08e36c4)

Direct leak of 983 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d4a4e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 5a053b2c39acdde66812d293604438f39b6f73db)
    #1 0x000000401ac4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x000000816ddb in init_info_raw /home/miguno/git/sil-q/src/init2.c:291
    #3 0x000000817e20 in init_info /home/miguno/git/sil-q/src/init2.c:412
    #4 0x000000819e70 in init_e_info /home/miguno/git/sil-q/src/init2.c:774
    #5 0x0000008217d2 in init_angband /home/miguno/git/sil-q/src/init2.c:1693
    #6 0x00000086abaa in main /home/miguno/git/sil-q/src/main.c:558
    #7 0x7f4d49a105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #8 0x7f4d49a10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #9 0x000000400ea4 in _start (/home/miguno/git/sil-q/sil+0x400ea4) (BuildId: 7d0488101deff1638a1bda565cea22f7b08e36c4)

Direct leak of 848 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d4a4e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 5a053b2c39acdde66812d293604438f39b6f73db)
    #1 0x000000401ac4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x00000081728c in init_info_raw /home/miguno/git/sil-q/src/init2.c:310
    #3 0x000000817e20 in init_info /home/miguno/git/sil-q/src/init2.c:412
    #4 0x00000081a766 in init_flavor_info /home/miguno/git/sil-q/src/init2.c:959
    #5 0x000000821880 in init_angband /home/miguno/git/sil-q/src/init2.c:1723
    #6 0x00000086abaa in main /home/miguno/git/sil-q/src/main.c:558
    #7 0x7f4d49a105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #8 0x7f4d49a10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #9 0x000000400ea4 in _start (/home/miguno/git/sil-q/sil+0x400ea4) (BuildId: 7d0488101deff1638a1bda565cea22f7b08e36c4)

SUMMARY: AddressSanitizer: 78202 byte(s) leaked in 7 allocation(s).
```
</p>
</details> 
