### PR TITLE
fix: memory leak in init_x11()

### DIFF
--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -2801,7 +2801,7 @@ errr init_x11(int argc, char** argv)
             }
 
             /* Free tiles_raw */
-            FREE(tiles_raw);
+            XDestroyImage(tiles_raw);
         }
 
         /* Initialize the transparency masks */


### PR DESCRIPTION
`FREE(tiles_raw)` frees the XImage struct itself, but not the `Data` buffer pointed to by `tiles_raw->Data`. Once the struct is freed, the only pointer to `Data` is lost, making the allocated memory permanently unreachable.

This change replaces `FREE(tiles_raw)` with `XDestroyImage(tiles_raw)`. The Xlib function XDestroyImage() properly frees both the XImage struct and its data buffer. Since `Data` was allocated with malloc()/ralloc(), the free() call inside XDestroyImage will correctly deallocate it.

## How to reproduce

Create a debug build with ASAN enabled. Then start the game on Linux in X11 mode (e.g., via `./silg`), then quit immediately with `d`.

```
==390019==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 524288 byte(s) in 1 object(s) allocated from:
    #0 0x7fe5542e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 25975f766867e9e604dc5a71a8befeaed3301942)
    #1 0x000000829ef4 in ralloc /home/miguno/git/sil-q/src/z-virt.c:63
    #2 0x0000008611be in ReadBMP /home/miguno/git/sil-q/src/maid-x11.c:329
    #3 0x00000085e23e in init_x11 /home/miguno/git/sil-q/src/main-x11.c:2746
    #4 0x000000869d90 in main /home/miguno/git/sil-q/src/main.c:544
    #5 0x7fe5538105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
    #6 0x7fe553810667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
    #7 0x000000400eb4 in _start (/home/miguno/git/sil-q/sil+0x400eb4) (BuildId: ddbb7c04089b11cc3f4e63a083259ccf8994065d)

SUMMARY: AddressSanitizer: 524288 byte(s) leaked in 1 allocation(s).
```