### PR TITLE
fix: abort firing when no valid path was found (buffer overflow)

### DIFF
--- a/src/cmd2.c
+++ b/src/cmd2.c
@@ -3824,6 +3824,10 @@ void do_cmd_fire(int quiver)
     path_n = project_path(
         path_g, tdis, p_ptr->py, p_ptr->px, &ty2, &tx2, PROJECT_THRU);
 
+    // Abort when no valid path was found.
+    if (path_n <= 0)
+        return;
+
     /* Hack -- Handle stuff */
     handle_stuff();
 


### PR DESCRIPTION
This prevents a stack buffer overflow in `do_cmd_fire()`. When running with ASAN enabled, this overflow will crash the game.

## Example overflow

`u16b [256]` (see first line of example) refers to `path_g[]` in this line that triggers the overflow:

```c
int final_y = GRID_Y(path_g[path_n - 1]);
```

Error trace:

```
    md2.c:3858:23: runtime error: index -1 out of bounds for type 'u16b [256]'
    =================================================================
    ==733652==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b12c98a0b7e at pc 0x0000006a615f bp 0x7ffd4ade09d0 sp 0x7ffd4ade09c8
    READ of size 2 at 0x7b12c98a0b7e thread T0
        #0 0x0000006a615e in do_cmd_fire src/cmd2.c:3858
        #1 0x0000007c86fd in process_command src/dungeon.c:1053
        #2 0x0000007d22d0 in process_player src/dungeon.c:1997
        #3 0x0000007db612 in dungeon src/dungeon.c:2721
        #4 0x0000007deb61 in play_game src/dungeon.c:3113
        #5 0x00000086a47c in main src/main.c:652
        #6 0x7f12cba105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
        #7 0x7f12cba10667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
        #8 0x000000400eb4 in _start (sil+0x400eb4) (BuildId: 1ba885349a4940c2624660e0ec13ed6da63c8b30)

    Address 0x7b12c98a0b7e is located in stack of thread T0 at offset 894 in frame
        #0 0x0000006a4626 in do_cmd_fire src/cmd2.c:3671

      This frame has 16 object(s):
        [32, 36) 'dir' (line 3672)
        [48, 52) 'ty2' (line 3674)
        [64, 68) 'tx2' (line 3675)
        [80, 84) 'f1' (line 3679)
        [96, 100) 'f2' (line 3679)
        [112, 116) 'f3' (line 3679)
        [128, 132) 'noticed_arrow_flag' (line 3710)
        [144, 148) 'noticed_bow_flag' (line 3712)
        [160, 180) 'punctuation' (line 3703)
        [224, 300) 'object_type_body' (line 3697)
        [336, 416) 'o_name' (line 3702)
        [448, 528) 'm_name' (line 4078)
        [560, 640) 'm_name' (line 4174)
        [672, 752) 'j_short_name' (line 4334)
        [784, 864) 'j_full_name' (line 4335)
        [896, 1408) 'path_g' (line 3706) <== Memory access at offset 894 underflows this variable
    HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
          (longjmp and C++ exceptions *are* supported)
    SUMMARY: AddressSanitizer: stack-buffer-overflow src/cmd2.c:3858 in do_cmd_fire
    Shadow bytes around the buggy address:
      0x7b12c98a0880: 04 f2 04 f2 00 00 04 f2 f2 f2 f2 f2 00 00 00 00
      0x7b12c98a0900: 00 00 00 00 00 04 f2 f2 f2 f2 00 00 00 00 00 00
      0x7b12c98a0980: 00 00 00 00 f2 f2 f2 f2 00 00 00 00 00 00 00 00
      0x7b12c98a0a00: 00 00 f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00
      0x7b12c98a0a80: f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00 f2 f2
    =>0x7b12c98a0b00: f2 f2 00 00 00 00 00 00 00 00 00 00 f2 f2 f2[f2]
      0x7b12c98a0b80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x7b12c98a0c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x7b12c98a0c80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x7b12c98a0d00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x7b12c98a0d80: f3 f3 f3 f3 f3 f3 f3 f3 00 00 00 00 00 00 00 00
    Shadow byte legend (one shadow byte represents 8 application bytes):
      Addressable:           00
      Partially addressable: 01 02 03 04 05 06 07
      Heap left redzone:       fa
      Freed heap region:       fd
      Stack left redzone:      f1
      Stack mid redzone:       f2
      Stack right redzone:     f3
      Stack after return:      f5
      Stack use after scope:   f8
      Global redzone:          f9
      Global init order:       f6
      Poisoned by user:        f7
      Container overflow:      fc
      Array cookie:            ac
      Intra object redzone:    bb
      ASan internal:           fe
      Left alloca redzone:     ca
      Right alloca redzone:    cb
    ==733652==ABORTING
```