### PR TITLE
Fix inconsistent house naming for Falathrim and Haleth

### DIFF
--- a/lib/edit/house.txt
+++ b/lib/edit/house.txt
@@ -110,8 +110,8 @@ D: and sorrow, slow to tears and to laughter; their fortitude needs
 D: no hope to sustain it. For the most part they have brown hair
 D: with brown or grey eyes.
 
-N:8:People of Haleth
-A:Haleth's People
+N:8:House of Haleth
+A:Haleth's House
 B:Haleth
 F:STL_AFFINITY
 S:0:1:0:0
@@ -133,7 +133,7 @@ D: tall, with flaxen or golden hair, blue-grey eyes and fair skin.
 # New Sindar House: should be moved into order when I next break savefile
 # compatibility (v 1.1?)
 
-N:10:Of the Falas
+N:10:Falathrim
 A:the Falas
 B:Falathrim
 F:ARC_AFFINITY


### PR DESCRIPTION
This PR resolves #164 by applying the suggested solution to make house naming consistent during character creation.

Changes:
- Updated "Of the Falas" to "Falathrim"
- Updated "People of Haleth" to "House of Haleth"

These changes prevent confusion caused by mismatched house names between the character creation wizard and the summary display.