### PR TITLE
Add validation scripts for all remaining `lib/edit/*.txt` game data files

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate
 
+      - name: Validate data file for flavors
+        run: python3 bin/data-flavor.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Validate data file for flavors
         run: python3 bin/data-flavor.py --validate
 
+      - name: Validate data file for history
+        run: python3 bin/data-history.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,6 +45,9 @@ jobs:
           file sil
           bin/smoke-tests.sh
 
+      - name: Validate data file for artefacts
+        run: python3 bin/data-artefact.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,6 +45,9 @@ jobs:
           file sil
           bin/smoke-tests.sh
 
+      - name: Validate data file for abilities
+        run: python3 bin/data-ability.py --validate
+
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Validate data file for houses
         run: python3 bin/data-house.py --validate
 
+      - name: Validate data file for limits
+        run: python3 bin/data-limits.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Validate data file for terrain
         run: python3 bin/data-terrain.py --validate
 
+      - name: Validate data file for vaults
+        run: python3 bin/data-vault.py --validate
+
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Validate data file for special items
         run: python3 bin/data-special.py --validate
 
+      - name: Validate data file for terrain
+        run: python3 bin/data-terrain.py --validate
+
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
+      - name: Validate data file for names
+        run: python3 bin/data-names.py --validate
+
       - name: Validate data file for objects
         run: python3 bin/data-object.py --validate
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Validate data file for history
         run: python3 bin/data-history.py --validate
 
+      - name: Validate data file for houses
+        run: python3 bin/data-house.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -44,6 +44,9 @@ jobs:
           file sil
           bin/smoke-tests.sh
 
+      - name: Validate data file for abilities
+        run: python3 bin/data-ability.py --validate
+
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate
 
@@ -126,6 +129,9 @@ jobs:
         run: |
           ls -la Sil.app
           file Sil.app/Contents/MacOS/sil
+
+      - name: Validate data file for abilities
+        run: python3 bin/data-ability.py --validate
 
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Validate data file for houses
         run: python3 bin/data-house.py --validate
 
+      - name: Validate data file for limits
+        run: python3 bin/data-limits.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
@@ -156,6 +159,9 @@ jobs:
 
       - name: Validate data file for houses
         run: python3 bin/data-house.py --validate
+
+      - name: Validate data file for limits
+        run: python3 bin/data-limits.py --validate
 
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
+      - name: Validate data file for names
+        run: python3 bin/data-names.py --validate
+
       - name: Validate data file for objects
         run: python3 bin/data-object.py --validate
 
@@ -144,6 +147,9 @@ jobs:
 
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
+
+      - name: Validate data file for names
+        run: python3 bin/data-names.py --validate
 
       - name: Validate data file for objects
         run: python3 bin/data-object.py --validate

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Validate data file for terrain
         run: python3 bin/data-terrain.py --validate
 
+      - name: Validate data file for vaults
+        run: python3 bin/data-vault.py --validate
+
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 
@@ -180,6 +183,9 @@ jobs:
 
       - name: Validate data file for terrain
         run: python3 bin/data-terrain.py --validate
+
+      - name: Validate data file for vaults
+        run: python3 bin/data-vault.py --validate
 
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate
 
+      - name: Validate data file for flavors
+        run: python3 bin/data-flavor.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
@@ -135,6 +138,9 @@ jobs:
 
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate
+
+      - name: Validate data file for flavors
+        run: python3 bin/data-flavor.py --validate
 
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Validate data file for flavors
         run: python3 bin/data-flavor.py --validate
 
+      - name: Validate data file for history
+        run: python3 bin/data-history.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
@@ -144,6 +147,9 @@ jobs:
 
       - name: Validate data file for flavors
         run: python3 bin/data-flavor.py --validate
+
+      - name: Validate data file for history
+        run: python3 bin/data-history.py --validate
 
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Validate data file for special items
         run: python3 bin/data-special.py --validate
 
+      - name: Validate data file for terrain
+        run: python3 bin/data-terrain.py --validate
+
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 
@@ -132,6 +135,9 @@ jobs:
 
       - name: Validate data file for special items
         run: python3 bin/data-special.py --validate
+
+      - name: Validate data file for terrain
+        run: python3 bin/data-terrain.py --validate
 
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -44,6 +44,9 @@ jobs:
           file sil
           bin/smoke-tests.sh
 
+      - name: Validate data file for artefacts
+        run: python3 bin/data-artefact.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
@@ -123,6 +126,9 @@ jobs:
         run: |
           ls -la Sil.app
           file Sil.app/Contents/MacOS/sil
+
+      - name: Validate data file for artefacts
+        run: python3 bin/data-artefact.py --validate
 
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Validate data file for history
         run: python3 bin/data-history.py --validate
 
+      - name: Validate data file for houses
+        run: python3 bin/data-house.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
@@ -150,6 +153,9 @@ jobs:
 
       - name: Validate data file for history
         run: python3 bin/data-history.py --validate
+
+      - name: Validate data file for houses
+        run: python3 bin/data-house.py --validate
 
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 
+      - name: Validate data file for names
+        run: python3 bin/data-names.py --validate
+
       - name: Validate data file for objects
         run: python3 bin/data-object.py --validate
 

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Validate data file for special items
         run: python3 bin/data-special.py --validate
 
+      - name: Validate data file for terrain
+        run: python3 bin/data-terrain.py --validate
+
       - name: Create release archive
         if: inputs.version != ''
         run: |

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 
+      - name: Validate data file for artefacts
+        run: python3 bin/data-artefact.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Validate data file for history
         run: python3 bin/data-history.py --validate
 
+      - name: Validate data file for houses
+        run: python3 bin/data-house.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Validate data file for terrain
         run: python3 bin/data-terrain.py --validate
 
+      - name: Validate data file for vaults
+        run: python3 bin/data-vault.py --validate
+
       - name: Create release archive
         if: inputs.version != ''
         run: |

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Validate data file for houses
         run: python3 bin/data-house.py --validate
 
+      - name: Validate data file for limits
+        run: python3 bin/data-limits.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Validate data file for flavors
         run: python3 bin/data-flavor.py --validate
 
+      - name: Validate data file for history
+        run: python3 bin/data-history.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 
+      - name: Validate data file for abilities
+        run: python3 bin/data-ability.py --validate
+
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate
 

--- a/.github/workflows/src.yml
+++ b/.github/workflows/src.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Validate data file for artefacts
         run: python3 bin/data-artefact.py --validate
 
+      - name: Validate data file for flavors
+        run: python3 bin/data-flavor.py --validate
+
       - name: Validate data file for monsters
         run: python3 bin/data-monster.py --validate
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Validate data file for special items
         run: python bin/data-special.py --validate
 
+      - name: Validate data file for terrain
+        run: python bin/data-terrain.py --validate
+
       - name: Remove outdated PDF manuals
         run: |
           rm lib/docs/*.pdf

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Validate data file for houses
         run: python bin/data-house.py --validate
 
+      - name: Validate data file for limits
+        run: python bin/data-limits.py --validate
+
       - name: Validate data file for monsters
         run: python bin/data-monster.py --validate
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 
+      - name: Validate data file for abilities
+        run: python bin/data-ability.py --validate
+
       - name: Validate data file for artefacts
         run: python bin/data-artefact.py --validate
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Validate data file for terrain
         run: python bin/data-terrain.py --validate
 
+      - name: Validate data file for vaults
+        run: python bin/data-vault.py --validate
+
       - name: Remove outdated PDF manuals
         run: |
           rm lib/docs/*.pdf

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Verify tutorial savefile
         run: bin/verify-tutorial.sh
 
+      - name: Validate data file for artefacts
+        run: python bin/data-artefact.py --validate
+
       - name: Validate data file for monsters
         run: python bin/data-monster.py --validate
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Validate data file for artefacts
         run: python bin/data-artefact.py --validate
 
+      - name: Validate data file for flavors
+        run: python bin/data-flavor.py --validate
+
       - name: Validate data file for monsters
         run: python bin/data-monster.py --validate
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Validate data file for monsters
         run: python bin/data-monster.py --validate
 
+      - name: Validate data file for names
+        run: python bin/data-names.py --validate
+
       - name: Validate data file for objects
         run: python bin/data-object.py --validate
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Validate data file for flavors
         run: python bin/data-flavor.py --validate
 
+      - name: Validate data file for history
+        run: python bin/data-history.py --validate
+
       - name: Validate data file for monsters
         run: python bin/data-monster.py --validate
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Validate data file for history
         run: python bin/data-history.py --validate
 
+      - name: Validate data file for houses
+        run: python bin/data-house.py --validate
+
       - name: Validate data file for monsters
         run: python bin/data-monster.py --validate
 

--- a/bin/data-ability.py
+++ b/bin/data-ability.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the ability.txt data file.
+
+1. Validates the format and integrity of lib/edit/ability.txt.
+2. Exports the ability records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: ability number : ability name
+- I: skill number : ability value : level requirement
+- P: prerequisite skill number / prerequisite ability value : ...
+- T: tval : sval_min : sval_max
+- D: description
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import re
+import signal
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limits:
+    """Limits parsed from lib/edit/limits.txt."""
+
+    max_abilities: int  # M:B value
+
+    @property
+    def max_ability_id(self) -> int:
+        """Maximum valid ability ID (0-indexed, so max_abilities - 1)."""
+        return self.max_abilities - 1
+
+
+@dataclass
+class Prerequisite:
+    """A prerequisite ability reference (P: line entry)."""
+
+    skill_id: int
+    ability_id: int
+
+
+@dataclass
+class ItemTypeRange:
+    """An item type range (T: line entry)."""
+
+    tval: int
+    sval_min: int
+    sval_max: int
+
+
+@dataclass
+class Ability:
+    """An ability record parsed from ability.txt."""
+
+    id: int
+    name: str
+    skill_id: int | None = None
+    ability_value: int | None = None
+    level_requirement: int | None = None
+    prerequisites: list[Prerequisite] = field(default_factory=list)
+    item_types: list[ItemTypeRange] = field(default_factory=list)
+    description: str | None = None
+
+
+def parse_limits_file(filepath: Path) -> Limits | None:
+    """Parse limits.txt and extract relevant limits.
+
+    Returns None if the file cannot be parsed.
+    """
+    if not filepath.exists():
+        return None
+
+    max_abilities = None
+
+    for line in filepath.read_text(encoding="latin-1").splitlines():
+        line = line.strip()
+        if line.startswith("M:B:"):
+            # M:B:240 - Maximum number of abilities
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[2].isdigit():
+                max_abilities = int(parts[2])
+
+    if max_abilities is None:
+        return None
+
+    return Limits(max_abilities=max_abilities)
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> int | None:
+    """Validate N: line format and return the ID."""
+    parts = line.split(":")
+    if len(parts) < 3:
+        result.error(f"Line {lineno}: N: line has {len(parts)} fields, expected at least 3: {line}")
+        return None
+
+    id_str = parts[1]
+    if not id_str.isdigit():
+        result.error(f"Line {lineno}: N: ID is not numeric: {id_str}")
+        return None
+
+    return int(id_str)
+
+
+def validate_i_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate I: line format (skill number : ability value : level requirement)."""
+    parts = line.split(":")
+    if len(parts) != 4:
+        result.error(f"Line {lineno}: I: line has {len(parts)} fields, expected 4: {line}")
+        return
+
+    for i, name in enumerate(["skill number", "ability value", "level requirement"], start=1):
+        val = parts[i]
+        if not val.isdigit():
+            result.error(f"Line {lineno}: I: {name} is not numeric: {val}")
+
+
+def validate_p_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate P: line format (prerequisite skill/ability pairs)."""
+    content = line[2:]  # Remove "P:"
+
+    # Standard format: skill/ability pairs separated by colons
+    pairs = content.split(":")
+    for pair in pairs:
+        pair = pair.strip()
+        if not re.match(r"^\d+/\d+$", pair):
+            result.error(f"Line {lineno}: P: invalid prerequisite '{pair}' (expected format: skill/ability)")
+
+
+def validate_t_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate T: line format (tval : sval_min : sval_max)."""
+    # Remove inline comments
+    if "#" in line:
+        line = line[: line.index("#")]
+    line = line.strip()
+
+    parts = line.split(":")
+    if len(parts) != 4:
+        result.error(f"Line {lineno}: T: line has {len(parts)} fields, expected 4: {line}")
+        return
+
+    for i, name in enumerate(["tval", "sval_min", "sval_max"], start=1):
+        val = parts[i].strip()
+        if not val.isdigit():
+            result.error(f"Line {lineno}: T: {name} is not numeric: {val}")
+
+
+def parse_prerequisites(line: str) -> list[Prerequisite]:
+    """Parse a P: line into a list of Prerequisite objects."""
+    content = line[2:]  # Remove "P:"
+    prerequisites: list[Prerequisite] = []
+
+    pairs = content.split(":")
+    for pair in pairs:
+        pair = pair.strip()
+        match = re.match(r"^(\d+)/(\d+)$", pair)
+        if match:
+            prerequisites.append(Prerequisite(skill_id=int(match.group(1)), ability_id=int(match.group(2))))
+
+    return prerequisites
+
+
+def parse_item_type(line: str) -> ItemTypeRange | None:
+    """Parse a T: line into an ItemTypeRange object."""
+    # Remove inline comments
+    if "#" in line:
+        line = line[: line.index("#")]
+    line = line.strip()
+
+    parts = line.split(":")
+    if len(parts) != 4:
+        return None
+
+    try:
+        return ItemTypeRange(
+            tval=int(parts[1].strip()),
+            sval_min=int(parts[2].strip()),
+            sval_max=int(parts[3].strip()),
+        )
+    except ValueError:
+        return None
+
+
+def parse_abilities(filepath: Path) -> list[Ability]:
+    """Parse ability.txt and return a list of Ability objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    abilities: list[Ability] = []
+    current_ability: Ability | None = None
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # N: line - start of new ability
+        if line.startswith("N:"):
+            # Save previous ability
+            if current_ability is not None:
+                abilities.append(current_ability)
+
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[1].isdigit():
+                current_ability = Ability(id=int(parts[1]), name=parts[2])
+            continue
+
+        if current_ability is None:
+            continue
+
+        # I: skill number : ability value : level requirement
+        if line.startswith("I:"):
+            parts = line.split(":")
+            if len(parts) >= 4:
+                if parts[1].isdigit():
+                    current_ability.skill_id = int(parts[1])
+                if parts[2].isdigit():
+                    current_ability.ability_value = int(parts[2])
+                if parts[3].isdigit():
+                    current_ability.level_requirement = int(parts[3])
+
+        # P: prerequisites
+        elif line.startswith("P:"):
+            prereqs = parse_prerequisites(line)
+            current_ability.prerequisites.extend(prereqs)
+
+        # T: item type range
+        elif line.startswith("T:"):
+            item_type = parse_item_type(line)
+            if item_type:
+                current_ability.item_types.append(item_type)
+
+        # D: description
+        elif line.startswith("D:"):
+            content = line[2:].strip()  # Remove "D:" and strip whitespace
+            if current_ability.description is None:
+                current_ability.description = content
+            else:
+                current_ability.description += " " + content
+
+    if current_ability is not None:
+        abilities.append(current_ability)
+
+    return abilities
+
+
+def export_abilities_to_json(abilities: list[Ability]) -> str:
+    """Export abilities to a JSON string."""
+
+    def clean_dict(d: JsonDict) -> JsonDict:
+        """Recursively remove None values and empty collections from a dict."""
+        result: JsonDict = {}
+        for k, v in d.items():
+            if v is None or v == [] or v == "":
+                continue
+            if isinstance(v, dict):
+                cleaned = clean_dict(v)
+                if cleaned:  # Only include non-empty dicts
+                    result[k] = cleaned
+            elif isinstance(v, list):
+                # Clean each item if it's a dict
+                cleaned_list: list[JsonValue] = []
+                for item in v:
+                    if isinstance(item, dict):
+                        cleaned_item = clean_dict(item)
+                        if cleaned_item:
+                            cleaned_list.append(cleaned_item)
+                    elif item is not None:
+                        cleaned_list.append(item)
+                if cleaned_list:
+                    result[k] = cleaned_list
+            else:
+                result[k] = v
+        return result
+
+    def ability_to_dict(ability: Ability) -> JsonDict:
+        """Convert an Ability to a dict, removing None values."""
+        return clean_dict(asdict(ability))
+
+    data = {"abilities": [ability_to_dict(a) for a in abilities]}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_ability_file(filepath: Path, limits: Limits | None = None) -> ValidationResult:
+    """Validate the entire ability.txt file.
+
+    Args:
+        filepath: Path to ability.txt file.
+        limits: Optional limits from limits.txt. If provided, validates
+                ability count and IDs against the maximum allowed.
+    """
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"Ability file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state. Maps id -> line number.
+    ids_seen: dict[int, int] = {}
+
+    prev_id = -1
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line - start of ability entry
+        if line.startswith("N:"):
+            ability_id = validate_n_line(line, lineno, result)
+            if ability_id is not None:
+                # Check for duplicates
+                if ability_id in ids_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate ID {ability_id} "
+                        + f"(first seen at line {ids_seen[ability_id]})"
+                    )
+                else:
+                    ids_seen[ability_id] = lineno
+
+                # Note: Ability IDs can have gaps (not strictly increasing by 1)
+                # but should generally increase
+                if ability_id < prev_id:
+                    result.warning(
+                        f"Line {lineno}: ID {ability_id} is less than previous ID {prev_id} "
+                        + "(IDs should generally increase)"
+                    )
+                prev_id = ability_id
+
+                # Check ID against limit
+                if limits and ability_id > limits.max_ability_id:
+                    result.error(
+                        f"Line {lineno}: Ability ID {ability_id} exceeds maximum allowed ID "
+                        + f"{limits.max_ability_id} (from limits.txt M:B:{limits.max_abilities})"
+                    )
+            continue
+
+        # Other line types
+        if line.startswith("I:"):
+            validate_i_line(line, lineno, result)
+        elif line.startswith("P:"):
+            validate_p_line(line, lineno, result)
+        elif line.startswith("T:"):
+            validate_t_line(line, lineno, result)
+        elif line.startswith("D:"):
+            pass  # D: lines are descriptions, no strict validation needed
+        else:
+            # Check for unknown line types (letter followed by colon)
+            if len(line) >= 2 and line[1] == ":":
+                result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+            else:
+                result.error(
+                    f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+                )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check total ability count against limit
+    if limits:
+        ability_count = len(ids_seen)
+        if ability_count > limits.max_abilities:
+            result.error(
+                f"Total ability count ({ability_count}) exceeds maximum allowed "
+                + f"({limits.max_abilities}) from limits.txt M:B"
+            )
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/ability.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                        # Validate the file
+  %(prog)s --validate lib/edit/ability.txt   # Validate a specific file
+  %(prog)s --export-json                     # Export to JSON (stdout)
+  %(prog)s --export-json > abilities.json    # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to ability.txt file (default: lib/edit/ability.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the ability.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all ability records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(ability_file: Path, limits_file: Path) -> int:
+    """Run validation on the ability file."""
+    print("=" * 60)
+    print(f"Validating: {ability_file}")
+
+    # Parse limits file
+    limits = parse_limits_file(limits_file)
+    if limits:
+        print(f"Limits: max abilities = {limits.max_abilities} (max ID = {limits.max_ability_id})")
+    else:
+        print(f"WARNING: Could not parse limits from {limits_file}", file=sys.stderr)
+
+    # Validate the file
+    result = validate_ability_file(ability_file, limits)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(ability_file: Path) -> int:
+    """Export abilities to JSON on stdout."""
+    abilities = parse_abilities(ability_file)
+
+    if not abilities:
+        print(f"ERROR: No abilities found in {ability_file}", file=sys.stderr)
+        return 1
+
+    print(export_abilities_to_json(abilities))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        ability_file = file_arg
+    else:
+        ability_file = project_dir / "lib" / "edit" / "ability.txt"
+
+    limits_file = project_dir / "lib" / "edit" / "limits.txt"
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(ability_file, limits_file)
+
+    if export_json:
+        return run_export_json(ability_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-ability.py
+++ b/bin/data-ability.py
@@ -58,7 +58,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-artefact.py
+++ b/bin/data-artefact.py
@@ -74,7 +74,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-artefact.py
+++ b/bin/data-artefact.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the artefact.txt data file.
+
+1. Validates the format and integrity of lib/edit/artefact.txt.
+2. Exports the artefact records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: serial number : item name
+- G: char : attr
+- I: tval : sval : pval
+- B: skilltype / abilitynum : ...
+- W: depth : rarity : weight : cost
+- P: attack bonus : damage dice : evasion bonus : protection dice
+- F: flag | flag | etc
+- D: text
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import re
+import signal
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+###
+### Valid colors
+###
+# Valid base colors (16 colors)
+# D - Dark Gray    w - White          s - Gray          o - Orange
+# r - Red          g - Green          b - Blue          u - Brown
+# d - Black        W - Light Gray     v - Violet        y - Yellow
+# R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
+VALID_BASE_COLORS = set("DwsorgbudWvyRGBU")
+# Extended colors observed in actual data (base color + numeric suffix)
+VALID_EXTENDED_COLORS = {"b1"}
+VALID_COLORS = VALID_BASE_COLORS | VALID_EXTENDED_COLORS
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limits:
+    """Limits parsed from lib/edit/limits.txt."""
+
+    special_artefacts: int  # M:A first value
+    normal_artefacts: int  # M:A second value
+
+    @property
+    def max_artefact_id(self) -> int:
+        """Maximum valid artefact ID (special + normal - 1, 0-indexed)."""
+        return self.special_artefacts + self.normal_artefacts - 1
+
+    @property
+    def total_artefacts(self) -> int:
+        """Total number of artefacts (special + normal)."""
+        return self.special_artefacts + self.normal_artefacts
+
+
+@dataclass
+class Ability:
+    """An ability reference (B: line entry)."""
+
+    skill_id: int
+    ability_id: int
+
+
+@dataclass
+class Artefact:
+    """An artefact record parsed from artefact.txt."""
+
+    id: int
+    name: str
+    symbol: str | None = None
+    color: str | None = None
+    tval: int | None = None
+    sval: int | None = None
+    pval: int | None = None
+    depth: int | None = None
+    rarity: int | None = None
+    weight: int | None = None
+    cost: int | None = None
+    attack_bonus: int | None = None
+    damage_dice: str | None = None
+    evasion_bonus: int | None = None
+    protection_dice: str | None = None
+    abilities: list[Ability] = field(default_factory=list)
+    flags: list[str] = field(default_factory=list)
+    description: str | None = None
+
+
+def parse_limits_file(filepath: Path) -> Limits | None:
+    """Parse limits.txt and extract relevant limits.
+
+    Returns None if the file cannot be parsed.
+    """
+    if not filepath.exists():
+        return None
+
+    for line in filepath.read_text(encoding="latin-1").splitlines():
+        line = line.strip()
+        if line.startswith("M:A:"):
+            # M:A:special:normal:random:self-made
+            parts = line.split(":")
+            if len(parts) >= 4 and parts[2].isdigit() and parts[3].isdigit():
+                return Limits(
+                    special_artefacts=int(parts[2]),
+                    normal_artefacts=int(parts[3]),
+                )
+
+    return None
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> int | None:
+    """Validate N: line format and return the ID."""
+    parts = line.split(":")
+    if len(parts) < 3:
+        result.error(f"Line {lineno}: N: line has {len(parts)} fields, expected at least 3: {line}")
+        return None
+
+    id_str = parts[1]
+    if not id_str.isdigit():
+        result.error(f"Line {lineno}: N: ID is not numeric: {id_str}")
+        return None
+
+    return int(id_str)
+
+
+def validate_g_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate G: line format (char : attr)."""
+    parts = line.split(":")
+    if len(parts) != 3:
+        result.error(f"Line {lineno}: G: line has {len(parts)} fields, expected 3: {line}")
+        return
+
+    color = parts[2]
+    if color not in VALID_COLORS:
+        result.error(f"Line {lineno}: G: unrecognized color '{color}'")
+
+
+def validate_i_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate I: line format (tval : sval : pval)."""
+    parts = line.split(":")
+    if len(parts) != 4:
+        result.error(f"Line {lineno}: I: line has {len(parts)} fields, expected 4: {line}")
+        return
+
+    for i, name in enumerate(["tval", "sval", "pval"], start=1):
+        val = parts[i]
+        if not re.match(r"^-?\d+$", val):
+            result.error(f"Line {lineno}: I: {name} is not a valid integer: {val}")
+
+
+def validate_b_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate B: line format (skilltype/abilitynum pairs or flags)."""
+    content = line[2:]  # Remove "B:"
+
+    # Check if it looks like flags (contains | and uppercase letters)
+    if "|" in content and re.search(r"[A-Z_]+", content):
+        # This is the flag format (e.g., "STR | RES_FEAR | FREE_ACT")
+        # This appears to be non-standard usage, but accept it
+        result.warning(f"Line {lineno}: B: line uses flag format instead of ability references: {line}")
+        return
+
+    # Standard format: skill/ability pairs separated by colons
+    pairs = content.split(":")
+    for pair in pairs:
+        pair = pair.strip()
+        if not re.match(r"^\d+/\d+$", pair):
+            result.error(f"Line {lineno}: B: invalid ability reference '{pair}' (expected format: skill/ability)")
+
+
+def validate_w_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate W: line format (depth : rarity : weight : cost)."""
+    parts = line.split(":")
+    if len(parts) != 5:
+        result.error(f"Line {lineno}: W: line has {len(parts)} fields, expected 5: {line}")
+        return
+
+    for i, name in enumerate(["depth", "rarity", "weight", "cost"], start=1):
+        val = parts[i]
+        if not val.isdigit():
+            result.error(f"Line {lineno}: W: {name} is not numeric: {val}")
+
+
+def validate_p_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate P: line format (attack bonus : damage dice : evasion bonus : protection dice).
+
+    Note: Some items (crowns/light sources) have a 5th value (always 0).
+    Bonuses can have a + prefix (e.g., +2, +11).
+    """
+    parts = line.split(":")
+    if len(parts) not in (5, 6):
+        result.error(f"Line {lineno}: P: line has {len(parts)} fields, expected 5 or 6: {line}")
+        return
+
+    # Attack bonus (can be negative or have + prefix)
+    if not re.match(r"^[+-]?\d+$", parts[1]):
+        result.error(f"Line {lineno}: P: attack bonus is not a valid integer: {parts[1]}")
+
+    # Damage dice (NdM format)
+    if not re.match(r"^\d+d\d+$", parts[2]):
+        result.error(f"Line {lineno}: P: damage dice has invalid format: {parts[2]}")
+
+    # Evasion bonus (can be negative or have + prefix)
+    if not re.match(r"^[+-]?\d+$", parts[3]):
+        result.error(f"Line {lineno}: P: evasion bonus is not a valid integer: {parts[3]}")
+
+    # Protection dice (NdM format)
+    if not re.match(r"^\d+d\d+$", parts[4]):
+        result.error(f"Line {lineno}: P: protection dice has invalid format: {parts[4]}")
+
+
+def parse_abilities(line: str) -> list[Ability]:
+    """Parse a B: line into a list of Ability objects."""
+    content = line[2:]  # Remove "B:"
+
+    # Skip if it looks like flags
+    if "|" in content and re.search(r"[A-Z_]+", content):
+        return []
+
+    abilities: list[Ability] = []
+    pairs = content.split(":")
+    for pair in pairs:
+        pair = pair.strip()
+        match = re.match(r"^(\d+)/(\d+)$", pair)
+        if match:
+            abilities.append(Ability(skill_id=int(match.group(1)), ability_id=int(match.group(2))))
+    return abilities
+
+
+def parse_artefacts(filepath: Path) -> list[Artefact]:
+    """Parse artefact.txt and return a list of Artefact objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    artefacts: list[Artefact] = []
+    current_artefact: Artefact | None = None
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # N: line - start of new artefact
+        if line.startswith("N:"):
+            # Save previous artefact
+            if current_artefact is not None:
+                artefacts.append(current_artefact)
+
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[1].isdigit():
+                current_artefact = Artefact(id=int(parts[1]), name=parts[2])
+            continue
+
+        if current_artefact is None:
+            continue
+
+        # G: char : attr
+        if line.startswith("G:"):
+            parts = line.split(":")
+            if len(parts) >= 3:
+                current_artefact.symbol = parts[1]
+                current_artefact.color = parts[2]
+
+        # I: tval : sval : pval
+        elif line.startswith("I:"):
+            parts = line.split(":")
+            if len(parts) >= 4:
+                if re.match(r"^-?\d+$", parts[1]):
+                    current_artefact.tval = int(parts[1])
+                if re.match(r"^-?\d+$", parts[2]):
+                    current_artefact.sval = int(parts[2])
+                if re.match(r"^-?\d+$", parts[3]):
+                    current_artefact.pval = int(parts[3])
+
+        # B: abilities
+        elif line.startswith("B:"):
+            abilities = parse_abilities(line)
+            current_artefact.abilities.extend(abilities)
+
+        # W: depth : rarity : weight : cost
+        elif line.startswith("W:"):
+            parts = line.split(":")
+            if len(parts) >= 5:
+                if parts[1].isdigit():
+                    current_artefact.depth = int(parts[1])
+                if parts[2].isdigit():
+                    current_artefact.rarity = int(parts[2])
+                if parts[3].isdigit():
+                    current_artefact.weight = int(parts[3])
+                if parts[4].isdigit():
+                    current_artefact.cost = int(parts[4])
+
+        # P: attack bonus : damage dice : evasion bonus : protection dice
+        elif line.startswith("P:"):
+            parts = line.split(":")
+            if len(parts) >= 5:
+                if re.match(r"^-?\d+$", parts[1]):
+                    current_artefact.attack_bonus = int(parts[1])
+                current_artefact.damage_dice = parts[2]
+                if re.match(r"^-?\d+$", parts[3]):
+                    current_artefact.evasion_bonus = int(parts[3])
+                current_artefact.protection_dice = parts[4]
+
+        # F: flags
+        elif line.startswith("F:"):
+            content = line[2:]  # Remove "F:"
+            flags = [f.strip() for f in content.split("|") if f.strip()]
+            current_artefact.flags.extend(flags)
+
+        # D: description
+        elif line.startswith("D:"):
+            content = line[2:].strip()  # Remove "D:" and strip whitespace
+            if current_artefact.description is None:
+                current_artefact.description = content
+            else:
+                current_artefact.description += " " + content
+
+    if current_artefact is not None:
+        artefacts.append(current_artefact)
+
+    return artefacts
+
+
+def export_artefacts_to_json(artefacts: list[Artefact]) -> str:
+    """Export artefacts to a JSON string."""
+
+    def clean_dict(d: JsonDict) -> JsonDict:
+        """Recursively remove None values and empty collections from a dict."""
+        result: JsonDict = {}
+        for k, v in d.items():
+            if v is None or v == [] or v == "":
+                continue
+            if isinstance(v, dict):
+                cleaned = clean_dict(v)
+                if cleaned:  # Only include non-empty dicts
+                    result[k] = cleaned
+            elif isinstance(v, list):
+                # Clean each item if it's a dict
+                cleaned_list: list[JsonValue] = []
+                for item in v:
+                    if isinstance(item, dict):
+                        cleaned_item = clean_dict(item)
+                        if cleaned_item:
+                            cleaned_list.append(cleaned_item)
+                    elif item is not None:
+                        cleaned_list.append(item)
+                if cleaned_list:
+                    result[k] = cleaned_list
+            else:
+                result[k] = v
+        return result
+
+    def artefact_to_dict(artefact: Artefact) -> JsonDict:
+        """Convert an Artefact to a dict, removing None values."""
+        d = clean_dict(asdict(artefact))
+        if "flags" in d and isinstance(d["flags"], list):
+            d["flags"] = cast(JsonValue, sorted(cast(list[str], d["flags"])))
+        return d
+
+    data = {"artefacts": [artefact_to_dict(a) for a in artefacts]}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_artefact_file(filepath: Path, limits: Limits | None = None) -> ValidationResult:
+    """Validate the entire artefact.txt file.
+
+    Args:
+        filepath: Path to artefact.txt file.
+        limits: Optional limits from limits.txt. If provided, validates
+                artefact count and IDs against the maximum allowed.
+    """
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"Artefact file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state. Maps id -> line number.
+    ids_seen: dict[int, int] = {}
+
+    prev_id = 0  # Artefacts start at 1
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line - start of artefact entry
+        if line.startswith("N:"):
+            artefact_id = validate_n_line(line, lineno, result)
+            if artefact_id is not None:
+                # Check for duplicates
+                if artefact_id in ids_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate ID {artefact_id} "
+                        + f"(first seen at line {ids_seen[artefact_id]})"
+                    )
+                else:
+                    ids_seen[artefact_id] = lineno
+
+                # Check IDs are increasing
+                if artefact_id <= prev_id:
+                    result.error(
+                        f"Line {lineno}: ID {artefact_id} is not greater than previous ID {prev_id} "
+                        + "(IDs must be strictly increasing)"
+                    )
+                prev_id = artefact_id
+
+                # Check ID against limit
+                if limits and artefact_id > limits.max_artefact_id:
+                    result.error(
+                        f"Line {lineno}: Artefact ID {artefact_id} exceeds maximum allowed ID "
+                        + f"{limits.max_artefact_id} (from limits.txt M:A)"
+                    )
+            continue
+
+        # Other line types
+        if line.startswith("G:"):
+            validate_g_line(line, lineno, result)
+        elif line.startswith("I:"):
+            validate_i_line(line, lineno, result)
+        elif line.startswith("B:"):
+            validate_b_line(line, lineno, result)
+        elif line.startswith("W:"):
+            validate_w_line(line, lineno, result)
+        elif line.startswith("P:"):
+            validate_p_line(line, lineno, result)
+        elif line.startswith("F:"):
+            pass  # F: lines are free-form flags, no strict validation needed
+        elif line.startswith("D:"):
+            pass  # D: lines are descriptions, no strict validation needed
+        else:
+            # Check for unknown line types (letter followed by colon)
+            if len(line) >= 2 and line[1] == ":":
+                result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+            else:
+                result.error(
+                    f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+                )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check total artefact count against limit
+    if limits:
+        artefact_count = len(ids_seen)
+        if artefact_count > limits.total_artefacts:
+            result.error(
+                f"Total artefact count ({artefact_count}) exceeds maximum allowed "
+                + f"({limits.total_artefacts}) from limits.txt M:A"
+            )
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/artefact.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                         # Validate the file
+  %(prog)s --validate lib/edit/artefact.txt   # Validate a specific file
+  %(prog)s --export-json                      # Export to JSON (stdout)
+  %(prog)s --export-json > artefacts.json     # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to artefact.txt file (default: lib/edit/artefact.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the artefact.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all artefact records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(artefact_file: Path, limits_file: Path) -> int:
+    """Run validation on the artefact file."""
+    print("=" * 60)
+    print(f"Validating: {artefact_file}")
+
+    # Parse limits file
+    limits = parse_limits_file(limits_file)
+    if limits:
+        print(f"Limits: max artefacts = {limits.total_artefacts} (max ID = {limits.max_artefact_id})")
+    else:
+        print(f"WARNING: Could not parse limits from {limits_file}", file=sys.stderr)
+
+    # Validate the file
+    result = validate_artefact_file(artefact_file, limits)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(artefact_file: Path) -> int:
+    """Export artefacts to JSON on stdout."""
+    artefacts = parse_artefacts(artefact_file)
+
+    if not artefacts:
+        print(f"ERROR: No artefacts found in {artefact_file}", file=sys.stderr)
+        return 1
+
+    print(export_artefacts_to_json(artefacts))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        artefact_file = file_arg
+    else:
+        artefact_file = project_dir / "lib" / "edit" / "artefact.txt"
+
+    limits_file = project_dir / "lib" / "edit" / "limits.txt"
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(artefact_file, limits_file)
+
+    if export_json:
+        return run_export_json(artefact_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-flavor.py
+++ b/bin/data-flavor.py
@@ -68,7 +68,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-flavor.py
+++ b/bin/data-flavor.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the flavor.txt data file.
+
+1. Validates the format and integrity of lib/edit/flavor.txt.
+2. Exports the flavor records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: index : tval : sval
+- G: char : attr
+- D: text
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import signal
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+###
+### Valid colors
+###
+# Valid base colors (16 colors)
+# D - Dark Gray    w - White          s - Gray          o - Orange
+# r - Red          g - Green          b - Blue          u - Brown
+# d - Black        W - Light Gray     v - Violet        y - Yellow
+# R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
+VALID_BASE_COLORS = set("DwsorgbudWvyRGBU")
+# Extended colors observed in actual data (base color + numeric suffix)
+VALID_EXTENDED_COLORS = {"b1", "g1", "v1", "r1", "G1", "U1", "D1", "W1", "u1", "B1", "y1"}
+VALID_COLORS = VALID_BASE_COLORS | VALID_EXTENDED_COLORS
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limits:
+    """Limits parsed from lib/edit/limits.txt."""
+
+    max_flavors: int  # M:L value
+
+    @property
+    def max_flavor_id(self) -> int:
+        """Maximum valid flavor ID (0-indexed, so max_flavors - 1)."""
+        return self.max_flavors - 1
+
+
+@dataclass
+class Flavor:
+    """A flavor record parsed from flavor.txt."""
+
+    id: int
+    tval: int
+    sval: int | None = None
+    symbol: str | None = None
+    color: str | None = None
+    description: str | None = None
+
+
+def parse_limits_file(filepath: Path) -> Limits | None:
+    """Parse limits.txt and extract relevant limits.
+
+    Returns None if the file cannot be parsed.
+    """
+    if not filepath.exists():
+        return None
+
+    max_flavors = None
+
+    for line in filepath.read_text(encoding="latin-1").splitlines():
+        line = line.strip()
+        if line.startswith("M:L:"):
+            # M:L:310 - Maximum number of flavors
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[2].isdigit():
+                max_flavors = int(parts[2])
+
+    if max_flavors is None:
+        return None
+
+    return Limits(max_flavors=max_flavors)
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> tuple[int, int] | None:
+    """Validate N: line format and return the (ID, tval) tuple."""
+    parts = line.split(":")
+    # N:index:tval or N:index:tval:sval
+    if len(parts) < 3:
+        result.error(f"Line {lineno}: N: line has {len(parts)} fields, expected at least 3: {line}")
+        return None
+
+    id_str = parts[1]
+    if not id_str.isdigit():
+        result.error(f"Line {lineno}: N: index is not numeric: {id_str}")
+        return None
+
+    tval_str = parts[2]
+    if not tval_str.isdigit():
+        result.error(f"Line {lineno}: N: tval is not numeric: {tval_str}")
+        return None
+
+    # sval is optional (field 4)
+    if len(parts) >= 4:
+        sval_str = parts[3]
+        if not sval_str.isdigit():
+            result.error(f"Line {lineno}: N: sval is not numeric: {sval_str}")
+            return None
+
+    return (int(id_str), int(tval_str))
+
+
+def validate_g_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate G: line format (char : attr)."""
+    parts = line.split(":")
+    if len(parts) != 3:
+        result.error(f"Line {lineno}: G: line has {len(parts)} fields, expected 3: {line}")
+        return
+
+    symbol = parts[1]
+    if len(symbol) != 1:
+        result.error(f"Line {lineno}: G: symbol must be single character, got '{symbol}'")
+
+    color = parts[2]
+    if color not in VALID_COLORS:
+        result.error(f"Line {lineno}: G: unrecognized color '{color}'")
+
+
+def parse_flavors(filepath: Path) -> list[Flavor]:
+    """Parse flavor.txt and return a list of Flavor objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    flavors: list[Flavor] = []
+    current_flavor: Flavor | None = None
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # N: line - start of new flavor
+        if line.startswith("N:"):
+            # Save previous flavor
+            if current_flavor is not None:
+                flavors.append(current_flavor)
+
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[1].isdigit() and parts[2].isdigit():
+                flavor_id = int(parts[1])
+                tval = int(parts[2])
+                sval = int(parts[3]) if len(parts) >= 4 and parts[3].isdigit() else None
+                current_flavor = Flavor(id=flavor_id, tval=tval, sval=sval)
+            continue
+
+        if current_flavor is None:
+            continue
+
+        # G: char : attr
+        if line.startswith("G:"):
+            parts = line.split(":")
+            if len(parts) >= 3:
+                current_flavor.symbol = parts[1]
+                current_flavor.color = parts[2]
+
+        # D: description
+        elif line.startswith("D:"):
+            content = line[2:].strip()
+            if current_flavor.description is None:
+                current_flavor.description = content
+            else:
+                current_flavor.description += " " + content
+
+    if current_flavor is not None:
+        flavors.append(current_flavor)
+
+    return flavors
+
+
+def export_flavors_to_json(flavors: list[Flavor]) -> str:
+    """Export flavors to a JSON string."""
+
+    def clean_dict(d: JsonDict) -> JsonDict:
+        """Recursively remove None values and empty collections from a dict."""
+        result: JsonDict = {}
+        for k, v in d.items():
+            if v is None or v == [] or v == "":
+                continue
+            if isinstance(v, dict):
+                cleaned = clean_dict(v)
+                if cleaned:  # Only include non-empty dicts
+                    result[k] = cleaned
+            elif isinstance(v, list):
+                # Clean each item if it's a dict
+                cleaned_list: list[JsonValue] = []
+                for item in v:
+                    if isinstance(item, dict):
+                        cleaned_item = clean_dict(item)
+                        if cleaned_item:
+                            cleaned_list.append(cleaned_item)
+                    elif item is not None:
+                        cleaned_list.append(item)
+                if cleaned_list:
+                    result[k] = cleaned_list
+            else:
+                result[k] = v
+        return result
+
+    def flavor_to_dict(flavor: Flavor) -> JsonDict:
+        """Convert a Flavor to a dict, removing None values."""
+        return clean_dict(asdict(flavor))
+
+    data = {"flavors": [flavor_to_dict(f) for f in flavors]}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_flavor_file(filepath: Path, limits: Limits | None = None) -> ValidationResult:
+    """Validate the entire flavor.txt file.
+
+    Args:
+        filepath: Path to flavor.txt file.
+        limits: Optional limits from limits.txt. If provided, validates
+                flavor count and IDs against the maximum allowed.
+    """
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"Flavor file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state. Maps id -> line number.
+    ids_seen: dict[int, int] = {}
+
+    prev_id = -1
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line - start of flavor entry
+        if line.startswith("N:"):
+            parsed = validate_n_line(line, lineno, result)
+            if parsed is not None:
+                flavor_id, _ = parsed
+                # Check for duplicates
+                if flavor_id in ids_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate ID {flavor_id} "
+                        + f"(first seen at line {ids_seen[flavor_id]})"
+                    )
+                else:
+                    ids_seen[flavor_id] = lineno
+
+                # Note: Flavor IDs can have gaps (not strictly increasing by 1)
+                # but should generally increase
+                if flavor_id < prev_id:
+                    result.warning(
+                        f"Line {lineno}: ID {flavor_id} is less than previous ID {prev_id} "
+                        + "(IDs should generally increase)"
+                    )
+                prev_id = flavor_id
+
+                # Check ID against limit
+                if limits and flavor_id > limits.max_flavor_id:
+                    result.error(
+                        f"Line {lineno}: Flavor ID {flavor_id} exceeds maximum allowed ID "
+                        + f"{limits.max_flavor_id} (from limits.txt M:L:{limits.max_flavors})"
+                    )
+            continue
+
+        # Other line types
+        if line.startswith("G:"):
+            validate_g_line(line, lineno, result)
+        elif line.startswith("D:"):
+            pass  # D: lines are descriptions, no strict validation needed
+        else:
+            # Check for unknown line types (letter followed by colon)
+            if len(line) >= 2 and line[1] == ":":
+                result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+            else:
+                result.error(
+                    f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+                )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check total flavor count against limit
+    if limits:
+        flavor_count = len(ids_seen)
+        if flavor_count > limits.max_flavors:
+            result.error(
+                f"Total flavor count ({flavor_count}) exceeds maximum allowed "
+                + f"({limits.max_flavors}) from limits.txt M:L"
+            )
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/flavor.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                      # Validate the file
+  %(prog)s --validate lib/edit/flavor.txt  # Validate a specific file
+  %(prog)s --export-json                   # Export to JSON (stdout)
+  %(prog)s --export-json > flavors.json    # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to flavor.txt file (default: lib/edit/flavor.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the flavor.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all flavor records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(flavor_file: Path, limits_file: Path) -> int:
+    """Run validation on the flavor file."""
+    print("=" * 60)
+    print(f"Validating: {flavor_file}")
+
+    # Parse limits file
+    limits = parse_limits_file(limits_file)
+    if limits:
+        print(f"Limits: max flavors = {limits.max_flavors} (max ID = {limits.max_flavor_id})")
+    else:
+        print(f"WARNING: Could not parse limits from {limits_file}", file=sys.stderr)
+
+    # Validate the file
+    result = validate_flavor_file(flavor_file, limits)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(flavor_file: Path) -> int:
+    """Export flavors to JSON on stdout."""
+    flavors = parse_flavors(flavor_file)
+
+    if not flavors:
+        print(f"ERROR: No flavors found in {flavor_file}", file=sys.stderr)
+        return 1
+
+    print(export_flavors_to_json(flavors))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        flavor_file = file_arg
+    else:
+        flavor_file = project_dir / "lib" / "edit" / "flavor.txt"
+
+    limits_file = project_dir / "lib" / "edit" / "limits.txt"
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(flavor_file, limits_file)
+
+    if export_json:
+        return run_export_json(flavor_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-history.py
+++ b/bin/data-history.py
@@ -54,7 +54,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-history.py
+++ b/bin/data-history.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the history.txt data file.
+
+1. Validates the format and integrity of lib/edit/history.txt.
+2. Exports the history records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: primary index : secondary index : probability : house
+- D: description
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import signal
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limits:
+    """Limits parsed from lib/edit/limits.txt."""
+
+    max_history_lines: int  # M:H value
+
+
+@dataclass
+class HistoryEntry:
+    """A history record parsed from history.txt."""
+
+    primary_index: int
+    secondary_index: int
+    probability: int
+    house: int
+    description: str | None = None
+
+
+def parse_limits_file(filepath: Path) -> Limits | None:
+    """Parse limits.txt and extract relevant limits.
+
+    Returns None if the file cannot be parsed.
+    """
+    if not filepath.exists():
+        return None
+
+    max_history_lines = None
+
+    for line in filepath.read_text(encoding="latin-1").splitlines():
+        line = line.strip()
+        if line.startswith("M:H:"):
+            # M:H:165 - Maximum number of player history lines
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[2].isdigit():
+                max_history_lines = int(parts[2])
+
+    if max_history_lines is None:
+        return None
+
+    return Limits(max_history_lines=max_history_lines)
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> bool:
+    """Validate N: line format. Returns True if valid."""
+    parts = line.split(":")
+    # N:primary:secondary:probability:house = 5 fields
+    if len(parts) != 5:
+        result.error(f"Line {lineno}: N: line has {len(parts)} fields, expected 5: {line}")
+        return False
+
+    field_names = ["primary index", "secondary index", "probability", "house"]
+    for i, name in enumerate(field_names, start=1):
+        val = parts[i]
+        if not val.isdigit():
+            result.error(f"Line {lineno}: N: {name} is not numeric: {val}")
+            return False
+
+    # Validate probability is 1-100
+    probability = int(parts[3])
+    if probability < 1 or probability > 100:
+        result.warning(f"Line {lineno}: N: probability {probability} is outside expected range 1-100")
+
+    return True
+
+
+def parse_history_entries(filepath: Path) -> list[HistoryEntry]:
+    """Parse history.txt and return a list of HistoryEntry objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    entries: list[HistoryEntry] = []
+    current_entry: HistoryEntry | None = None
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # N: line - start of new entry
+        if line.startswith("N:"):
+            # Save previous entry
+            if current_entry is not None:
+                entries.append(current_entry)
+
+            parts = line.split(":")
+            if len(parts) == 5:
+                try:
+                    current_entry = HistoryEntry(
+                        primary_index=int(parts[1]),
+                        secondary_index=int(parts[2]),
+                        probability=int(parts[3]),
+                        house=int(parts[4]),
+                    )
+                except ValueError:
+                    current_entry = None
+            continue
+
+        if current_entry is None:
+            continue
+
+        # D: description
+        if line.startswith("D:"):
+            content = line[2:]  # Keep spacing as-is per file comments
+            if current_entry.description is None:
+                current_entry.description = content
+            else:
+                current_entry.description += " " + content
+
+    if current_entry is not None:
+        entries.append(current_entry)
+
+    return entries
+
+
+def export_history_to_json(entries: list[HistoryEntry]) -> str:
+    """Export history entries to a JSON string."""
+
+    def clean_dict(d: JsonDict) -> JsonDict:
+        """Recursively remove None values and empty collections from a dict."""
+        result: JsonDict = {}
+        for k, v in d.items():
+            if v is None or v == [] or v == "":
+                continue
+            if isinstance(v, dict):
+                cleaned = clean_dict(v)
+                if cleaned:
+                    result[k] = cleaned
+            elif isinstance(v, list):
+                cleaned_list: list[JsonValue] = []
+                for item in v:
+                    if isinstance(item, dict):
+                        cleaned_item = clean_dict(item)
+                        if cleaned_item:
+                            cleaned_list.append(cleaned_item)
+                    elif item is not None:
+                        cleaned_list.append(item)
+                if cleaned_list:
+                    result[k] = cleaned_list
+            else:
+                result[k] = v
+        return result
+
+    def entry_to_dict(entry: HistoryEntry) -> JsonDict:
+        """Convert a HistoryEntry to a dict, removing None values."""
+        return clean_dict(asdict(entry))
+
+    data = {"history": [entry_to_dict(e) for e in entries]}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_history_file(filepath: Path, limits: Limits | None = None) -> ValidationResult:
+    """Validate the entire history.txt file.
+
+    Args:
+        filepath: Path to history.txt file.
+        limits: Optional limits from limits.txt.
+    """
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"History file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    entry_count = 0
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line - start of history entry
+        if line.startswith("N:"):
+            if validate_n_line(line, lineno, result):
+                entry_count += 1
+            continue
+
+        # D: line - description
+        if line.startswith("D:"):
+            # D: lines are descriptions, no strict validation needed
+            continue
+
+        # Unknown line types
+        if len(line) >= 2 and line[1] == ":":
+            result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+        else:
+            result.error(
+                f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+            )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check total entry count against limit
+    if limits:
+        if entry_count > limits.max_history_lines:
+            result.error(
+                f"Total history entry count ({entry_count}) exceeds maximum allowed "
+                + f"({limits.max_history_lines}) from limits.txt M:H"
+            )
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/history.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                       # Validate the file
+  %(prog)s --validate lib/edit/history.txt  # Validate a specific file
+  %(prog)s --export-json                    # Export to JSON (stdout)
+  %(prog)s --export-json > history.json     # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to history.txt file (default: lib/edit/history.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the history.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all history records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(history_file: Path, limits_file: Path) -> int:
+    """Run validation on the history file."""
+    print("=" * 60)
+    print(f"Validating: {history_file}")
+
+    # Parse limits file
+    limits = parse_limits_file(limits_file)
+    if limits:
+        print(f"Limits: max history lines = {limits.max_history_lines}")
+    else:
+        print(f"WARNING: Could not parse limits from {limits_file}", file=sys.stderr)
+
+    # Validate the file
+    result = validate_history_file(history_file, limits)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(history_file: Path) -> int:
+    """Export history entries to JSON on stdout."""
+    entries = parse_history_entries(history_file)
+
+    if not entries:
+        print(f"ERROR: No history entries found in {history_file}", file=sys.stderr)
+        return 1
+
+    print(export_history_to_json(entries))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        history_file = file_arg
+    else:
+        history_file = project_dir / "lib" / "edit" / "history.txt"
+
+    limits_file = project_dir / "lib" / "edit" / "limits.txt"
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(history_file, limits_file)
+
+    if export_json:
+        return run_export_json(history_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-house.py
+++ b/bin/data-house.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the house.txt data file.
+
+1. Validates the format and integrity of lib/edit/house.txt.
+2. Exports the house records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: house number : house name
+- A: alternate house name
+- B: short house name
+- F: house flag
+- S: str : dex : con : gra
+- D: description
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import signal
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+# Valid house flags
+VALID_FLAGS = {
+    "SMT_AFFINITY",
+    "WIL_AFFINITY",
+    "PER_AFFINITY",
+    "SNG_AFFINITY",
+    "EVN_AFFINITY",
+    "STL_AFFINITY",
+    "MEL_AFFINITY",
+    "ARC_AFFINITY",
+}
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limits:
+    """Limits parsed from lib/edit/limits.txt."""
+
+    max_houses: int  # M:C value
+
+    @property
+    def max_house_id(self) -> int:
+        """Maximum valid house ID (0-indexed, so max_houses - 1)."""
+        return self.max_houses - 1
+
+
+@dataclass
+class House:
+    """A house record parsed from house.txt."""
+
+    id: int
+    name: str
+    alternate_name: str | None = None
+    short_name: str | None = None
+    flag: str | None = None
+    stats: list[int] = field(default_factory=list)
+    description: str | None = None
+
+
+def parse_limits_file(filepath: Path) -> Limits | None:
+    """Parse limits.txt and extract relevant limits.
+
+    Returns None if the file cannot be parsed.
+    """
+    if not filepath.exists():
+        return None
+
+    max_houses = None
+
+    for line in filepath.read_text(encoding="latin-1").splitlines():
+        line = line.strip()
+        if line.startswith("M:C:"):
+            # M:C:11 - Maximum number of player houses
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[2].isdigit():
+                max_houses = int(parts[2])
+
+    if max_houses is None:
+        return None
+
+    return Limits(max_houses=max_houses)
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> int | None:
+    """Validate N: line format and return the ID."""
+    parts = line.split(":")
+    if len(parts) < 3:
+        result.error(f"Line {lineno}: N: line has {len(parts)} fields, expected at least 3: {line}")
+        return None
+
+    id_str = parts[1]
+    if not id_str.isdigit():
+        result.error(f"Line {lineno}: N: house number is not numeric: {id_str}")
+        return None
+
+    return int(id_str)
+
+
+def validate_s_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate S: line format (str : dex : con : gra)."""
+    parts = line.split(":")
+    if len(parts) != 5:
+        result.error(f"Line {lineno}: S: line has {len(parts)} fields, expected 5: {line}")
+        return
+
+    for i, name in enumerate(["str", "dex", "con", "gra"], start=1):
+        val = parts[i]
+        # Stats can be negative, so check for optional minus sign
+        if not (val.isdigit() or (val.startswith("-") and val[1:].isdigit())):
+            result.error(f"Line {lineno}: S: {name} is not numeric: {val}")
+
+
+def validate_f_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate F: line format (house flag)."""
+    parts = line.split(":")
+    if len(parts) < 2:
+        result.error(f"Line {lineno}: F: line missing flag: {line}")
+        return
+
+    flag = parts[1].strip()
+    if flag and flag not in VALID_FLAGS:
+        result.warning(f"Line {lineno}: F: unrecognized flag '{flag}'")
+
+
+def parse_houses(filepath: Path) -> list[House]:
+    """Parse house.txt and return a list of House objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    houses: list[House] = []
+    current_house: House | None = None
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # N: line - start of new house
+        if line.startswith("N:"):
+            # Save previous house
+            if current_house is not None:
+                houses.append(current_house)
+
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[1].isdigit():
+                current_house = House(id=int(parts[1]), name=":".join(parts[2:]))
+            continue
+
+        if current_house is None:
+            continue
+
+        # A: alternate name
+        if line.startswith("A:"):
+            current_house.alternate_name = line[2:].strip()
+
+        # B: short name
+        elif line.startswith("B:"):
+            current_house.short_name = line[2:].strip()
+
+        # F: flag
+        elif line.startswith("F:"):
+            current_house.flag = line[2:].strip()
+
+        # S: stats
+        elif line.startswith("S:"):
+            parts = line.split(":")
+            if len(parts) == 5:
+                try:
+                    current_house.stats = [int(parts[i]) for i in range(1, 5)]
+                except ValueError:
+                    pass
+
+        # D: description
+        elif line.startswith("D:"):
+            content = line[2:]
+            if current_house.description is None:
+                current_house.description = content
+            else:
+                current_house.description += " " + content
+
+    if current_house is not None:
+        houses.append(current_house)
+
+    return houses
+
+
+def export_houses_to_json(houses: list[House]) -> str:
+    """Export houses to a JSON string."""
+
+    def clean_dict(d: JsonDict) -> JsonDict:
+        """Recursively remove None values and empty collections from a dict."""
+        result: JsonDict = {}
+        for k, v in d.items():
+            if v is None or v == [] or v == "":
+                continue
+            if isinstance(v, dict):
+                cleaned = clean_dict(v)
+                if cleaned:
+                    result[k] = cleaned
+            elif isinstance(v, list):
+                cleaned_list: list[JsonValue] = []
+                for item in v:
+                    if isinstance(item, dict):
+                        cleaned_item = clean_dict(item)
+                        if cleaned_item:
+                            cleaned_list.append(cleaned_item)
+                    elif item is not None:
+                        cleaned_list.append(item)
+                if cleaned_list:
+                    result[k] = cleaned_list
+            else:
+                result[k] = v
+        return result
+
+    def house_to_dict(house: House) -> JsonDict:
+        """Convert a House to a dict, removing None values."""
+        return clean_dict(asdict(house))
+
+    data = {"houses": [house_to_dict(h) for h in houses]}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_house_file(filepath: Path, limits: Limits | None = None) -> ValidationResult:
+    """Validate the entire house.txt file.
+
+    Args:
+        filepath: Path to house.txt file.
+        limits: Optional limits from limits.txt.
+    """
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"House file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state. Maps id -> line number.
+    ids_seen: dict[int, int] = {}
+    prev_id = -1
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line - start of house entry
+        if line.startswith("N:"):
+            house_id = validate_n_line(line, lineno, result)
+            if house_id is not None:
+                # Check for duplicates
+                if house_id in ids_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate ID {house_id} "
+                        + f"(first seen at line {ids_seen[house_id]})"
+                    )
+                else:
+                    ids_seen[house_id] = lineno
+
+                # Check IDs are increasing
+                if house_id <= prev_id:
+                    result.warning(
+                        f"Line {lineno}: ID {house_id} is not greater than previous ID {prev_id}"
+                    )
+                prev_id = house_id
+
+                # Check ID against limit
+                if limits and house_id > limits.max_house_id:
+                    result.error(
+                        f"Line {lineno}: House ID {house_id} exceeds maximum allowed ID "
+                        + f"{limits.max_house_id} (from limits.txt M:C:{limits.max_houses})"
+                    )
+            continue
+
+        # Other line types
+        if line.startswith("A:"):
+            pass  # Alternate name, no strict validation
+        elif line.startswith("B:"):
+            pass  # Short name, no strict validation
+        elif line.startswith("F:"):
+            validate_f_line(line, lineno, result)
+        elif line.startswith("S:"):
+            validate_s_line(line, lineno, result)
+        elif line.startswith("D:"):
+            pass  # Description, no strict validation
+        else:
+            # Unknown line types
+            if len(line) >= 2 and line[1] == ":":
+                result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+            else:
+                result.error(
+                    f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+                )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check total house count against limit
+    if limits:
+        house_count = len(ids_seen)
+        if house_count > limits.max_houses:
+            result.error(
+                f"Total house count ({house_count}) exceeds maximum allowed "
+                + f"({limits.max_houses}) from limits.txt M:C"
+            )
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/house.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                     # Validate the file
+  %(prog)s --validate lib/edit/house.txt  # Validate a specific file
+  %(prog)s --export-json                  # Export to JSON (stdout)
+  %(prog)s --export-json > houses.json    # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to house.txt file (default: lib/edit/house.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the house.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all house records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(house_file: Path, limits_file: Path) -> int:
+    """Run validation on the house file."""
+    print("=" * 60)
+    print(f"Validating: {house_file}")
+
+    # Parse limits file
+    limits = parse_limits_file(limits_file)
+    if limits:
+        print(f"Limits: max houses = {limits.max_houses} (max ID = {limits.max_house_id})")
+    else:
+        print(f"WARNING: Could not parse limits from {limits_file}", file=sys.stderr)
+
+    # Validate the file
+    result = validate_house_file(house_file, limits)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(house_file: Path) -> int:
+    """Export houses to JSON on stdout."""
+    houses = parse_houses(house_file)
+
+    if not houses:
+        print(f"ERROR: No houses found in {house_file}", file=sys.stderr)
+        return 1
+
+    print(export_houses_to_json(houses))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        house_file = file_arg
+    else:
+        house_file = project_dir / "lib" / "edit" / "house.txt"
+
+    limits_file = project_dir / "lib" / "edit" / "limits.txt"
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(house_file, limits_file)
+
+    if export_json:
+        return run_export_json(house_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-house.py
+++ b/bin/data-house.py
@@ -70,7 +70,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-limits.py
+++ b/bin/data-limits.py
@@ -92,7 +92,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-limits.py
+++ b/bin/data-limits.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the limits.txt data file.
+
+1. Validates the format and integrity of lib/edit/limits.txt.
+2. Exports the limit records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the inline comments in limits.txt:
+- M:F:value - Maximum number of feature types
+- M:K:value - Maximum number of object kinds
+- M:B:value - Maximum number of abilities
+- M:A:special:normal:random:self-made - Artifact limits (4 values)
+- M:E:value - Maximum number of special item types
+- M:R:value - Maximum number of monster races
+- M:G:value - Maximum number of ghost templates
+- M:V:value - Maximum number of vaults
+- M:P:value - Maximum number of player races
+- M:C:value - Maximum number of player houses
+- M:H:value - Maximum number of player history lines
+- M:Q:value - Maximum number of quests
+- M:L:value - Maximum number of flavors
+- M:O:value - Maximum number of objects on level
+- M:N:value - Size of names array (bytes)
+- M:T:value - Size of descriptions array (bytes)
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import signal
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+# Known limit codes and their expected field counts (after M:code:)
+# Most have 1 value, M:A has 4 values
+LIMIT_CODES: dict[str, tuple[str, int]] = {
+    "F": ("feature_types", 1),
+    "K": ("object_kinds", 1),
+    "B": ("abilities", 1),
+    "A": ("artefacts", 4),  # special:normal:random:self-made
+    "E": ("special_items", 1),
+    "R": ("monster_races", 1),
+    "G": ("ghost_templates", 1),
+    "V": ("vaults", 1),
+    "P": ("player_races", 1),
+    "C": ("player_houses", 1),
+    "H": ("history_lines", 1),
+    "Q": ("quests", 1),
+    "L": ("flavors", 1),
+    "O": ("objects_on_level", 1),
+    "N": ("names_array_size", 1),
+    "T": ("descriptions_array_size", 1),
+}
+
+# Artefact sub-field names for M:A line (special:normal:random:self-made)
+ARTEFACT_FIELDS = ["special", "normal", "random", "selfmade"]
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limit:
+    """A limit record parsed from limits.txt."""
+
+    code: str
+    name: str
+    values: list[int]
+
+
+def validate_m_line(line: str, lineno: int, result: ValidationResult) -> Limit | None:
+    """Validate M: line format and return a Limit object."""
+    parts = line.split(":")
+    if len(parts) < 3:
+        result.error(f"Line {lineno}: M: line has {len(parts)} fields, expected at least 3: {line}")
+        return None
+
+    code = parts[1]
+    if code not in LIMIT_CODES:
+        result.warning(f"Line {lineno}: M: unknown limit code '{code}': {line}")
+        # Still try to parse it
+        name = f"unknown_{code}"
+        expected_count = len(parts) - 2
+    else:
+        name, expected_count = LIMIT_CODES[code]
+
+    # Validate value count
+    actual_count = len(parts) - 2
+    if actual_count != expected_count:
+        result.error(
+            f"Line {lineno}: M:{code}: has {actual_count} values, expected {expected_count}: {line}"
+        )
+        return None
+
+    # Validate all values are numeric
+    values: list[int] = []
+    for i, val in enumerate(parts[2:], start=1):
+        if not val.isdigit():
+            result.error(f"Line {lineno}: M:{code}: value {i} is not numeric: {val}")
+            return None
+        values.append(int(val))
+
+    return Limit(code=code, name=name, values=values)
+
+
+def parse_limits(filepath: Path) -> list[Limit]:
+    """Parse limits.txt and return a list of Limit objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    limits: list[Limit] = []
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # M: line
+        if line.startswith("M:"):
+            parts = line.split(":")
+            if len(parts) >= 3:
+                code = parts[1]
+                if code in LIMIT_CODES:
+                    name, _ = LIMIT_CODES[code]
+                else:
+                    name = f"unknown_{code}"
+                try:
+                    values = [int(v) for v in parts[2:]]
+                    limits.append(Limit(code=code, name=name, values=values))
+                except ValueError:
+                    pass
+
+    return limits
+
+
+def export_limits_to_json(limits: list[Limit]) -> str:
+    """Export limits to a JSON string."""
+    data: JsonDict = {"limits": {}}
+    limits_dict = cast(JsonDict, data["limits"])
+
+    for limit in limits:
+        if len(limit.values) == 1:
+            limits_dict[limit.name] = limit.values[0]
+        elif limit.name == "artefacts" and len(limit.values) == len(ARTEFACT_FIELDS):
+            # Create nested artefacts map
+            artefacts: JsonDict = {}
+            for field_name, value in zip(ARTEFACT_FIELDS, limit.values, strict=True):
+                artefacts[field_name] = value
+            artefacts["total"] = sum(limit.values)
+            limits_dict["artefacts"] = artefacts
+        else:
+            limits_dict[limit.name] = limit.values
+
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_limits_file(filepath: Path) -> ValidationResult:
+    """Validate the entire limits.txt file."""
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"Limits file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state
+    codes_seen: dict[str, int] = {}  # Maps code -> line number
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # M: line
+        if line.startswith("M:"):
+            limit = validate_m_line(line, lineno, result)
+            if limit is not None:
+                # Check for duplicates
+                if limit.code in codes_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate limit code '{limit.code}' "
+                        + f"(first seen at line {codes_seen[limit.code]})"
+                    )
+                else:
+                    codes_seen[limit.code] = lineno
+            continue
+
+        # Unknown line types
+        if len(line) >= 2 and line[1] == ":":
+            result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+        else:
+            result.error(
+                f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+            )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check that all expected limit codes are present
+    for code in LIMIT_CODES:
+        if code not in codes_seen:
+            result.warning(f"Missing expected limit code 'M:{code}'")
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/limits.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                      # Validate the file
+  %(prog)s --validate lib/edit/limits.txt  # Validate a specific file
+  %(prog)s --export-json                   # Export to JSON (stdout)
+  %(prog)s --export-json > limits.json     # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to limits.txt file (default: lib/edit/limits.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the limits.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all limit records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(limits_file: Path) -> int:
+    """Run validation on the limits file."""
+    print("=" * 60)
+    print(f"Validating: {limits_file}")
+
+    # Validate the file
+    result = validate_limits_file(limits_file)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(limits_file: Path) -> int:
+    """Export limits to JSON on stdout."""
+    limits = parse_limits(limits_file)
+
+    if not limits:
+        print(f"ERROR: No limits found in {limits_file}", file=sys.stderr)
+        return 1
+
+    print(export_limits_to_json(limits))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        limits_file = file_arg
+    else:
+        limits_file = project_dir / "lib" / "edit" / "limits.txt"
+
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(limits_file)
+
+    if export_json:
+        return run_export_json(limits_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-monster.py
+++ b/bin/data-monster.py
@@ -37,13 +37,40 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import cast
 
-# JSON-compatible types
-type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
-type JsonDict = dict[str, JsonValue]
-
 # Handle broken pipe (e.g., when piping to head) - Unix only
 if hasattr(signal, "SIGPIPE"):
     _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+###
+### Valid colors
+###
+# Valid base colors (16 colors)
+# D - Dark Gray    w - White          s - Gray          o - Orange
+# r - Red          g - Green          b - Blue          u - Brown
+# d - Black        W - Light Gray     v - Violet        y - Yellow
+# R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
+#
+# Note: The actual file also uses extended colors with numeric suffixes
+# (e.g., D1, v1, y1) which are not documented in the comment section.
+VALID_BASE_COLORS = {"D", "w", "s", "o", "r", "g", "b", "u", "d", "W", "v", "y", "R", "G", "B", "U"}
+# Extended colors observed in actual data (base color + numeric suffix)
+VALID_EXTENDED_COLORS = {"D1", "v1", "y1", "U1", "G1", "B1", "b1"}
+VALID_COLORS = VALID_BASE_COLORS | VALID_EXTENDED_COLORS
+
+###
+### Regex patterns for validation
+###
+DICE_PATTERN = re.compile(r"^\d+d\d+$")
+PROTECTION_PATTERN = re.compile(r"^\[[+-]\d+(,\d+d\d+)?\]$")
+# Damage can be (+N,NdM) or just (+N) for effects that don't deal damage
+DAMAGE_PATTERN = re.compile(r"^\([+-]\d+(,\d+d\d+)?\)$")
+SPELL_PCT_PATTERN = re.compile(r"SPELL_PCT_\d+")
+# Light radius can be negative (creature creates darkness)
+LIGHT_RADIUS_PATTERN = re.compile(r"^-?\d+$")
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
 
 
 @dataclass
@@ -64,30 +91,6 @@ class ValidationResult:
     @property
     def is_valid(self) -> bool:
         return len(self.errors) == 0
-
-
-# Valid colors per the documented specification (16 colors):
-# D - Dark Gray    w - White          s - Gray          o - Orange
-# r - Red          g - Green          b - Blue          u - Brown
-# d - Black        W - Light Gray     v - Violet        y - Yellow
-# R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
-#
-# Note: The actual file also uses extended colors with numeric suffixes
-# (e.g., D1, v1, y1) which are not documented in the comment section.
-DOCUMENTED_COLORS = {"D", "w", "s", "o", "r", "g", "b", "u", "d", "W", "v", "y", "R", "G", "B", "U"}
-EXTENDED_COLORS = {"D1", "v1", "y1", "U1", "G1", "B1", "b1"}
-VALID_COLORS = DOCUMENTED_COLORS | EXTENDED_COLORS
-
-###
-### Regex patterns for validation
-###
-DICE_PATTERN = re.compile(r"^\d+d\d+$")
-PROTECTION_PATTERN = re.compile(r"^\[[+-]\d+(,\d+d\d+)?\]$")
-# Damage can be (+N,NdM) or just (+N) for effects that don't deal damage
-DAMAGE_PATTERN = re.compile(r"^\([+-]\d+(,\d+d\d+)?\)$")
-SPELL_PCT_PATTERN = re.compile(r"SPELL_PCT_\d+")
-# Light radius can be negative (creature creates darkness)
-LIGHT_RADIUS_PATTERN = re.compile(r"^-?\d+$")
 
 
 @dataclass

--- a/bin/data-monster.py
+++ b/bin/data-monster.py
@@ -90,7 +90,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-names.py
+++ b/bin/data-names.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the names.txt data file.
+
+1. Validates the format and integrity of lib/edit/names.txt.
+2. Exports the name records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: name
+
+Additional constraints from comments:
+- Every word (data record) must be unique.
+- Data records should be in alphabetical order.
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import signal
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Name:
+    """A name record parsed from names.txt."""
+
+    name: str
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> str | None:
+    """Validate N: line format and return the name."""
+    parts = line.split(":", 1)  # Split only on first colon
+    if len(parts) < 2:
+        result.error(f"Line {lineno}: N: line missing name: {line}")
+        return None
+
+    name = parts[1].strip()
+    if not name:
+        result.error(f"Line {lineno}: N: line has empty name: {line}")
+        return None
+
+    return name
+
+
+def parse_names(filepath: Path) -> list[Name]:
+    """Parse names.txt and return a list of Name objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    names: list[Name] = []
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # N: line
+        if line.startswith("N:"):
+            parts = line.split(":", 1)
+            if len(parts) >= 2:
+                name = parts[1].strip()
+                if name:
+                    names.append(Name(name=name))
+
+    return names
+
+
+def export_names_to_json(names: list[Name]) -> str:
+    """Export names to a JSON string, sorted alphabetically."""
+    sorted_names = sorted(n.name for n in names)
+    data = {"names": sorted_names}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_names_file(filepath: Path) -> ValidationResult:
+    """Validate the entire names.txt file."""
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"Names file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state
+    names_seen: dict[str, int] = {}  # Maps name -> line number
+    prev_name: str | None = None
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line
+        if line.startswith("N:"):
+            name = validate_n_line(line, lineno, result)
+            if name is not None:
+                # Check for duplicates
+                if name in names_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate name '{name}' "
+                        + f"(first seen at line {names_seen[name]})"
+                    )
+                else:
+                    names_seen[name] = lineno
+
+                # Check alphabetical ordering
+                if prev_name is not None and name < prev_name:
+                    result.warning(
+                        f"Line {lineno}: Name '{name}' is not in alphabetical order "
+                        + f"(comes after '{prev_name}')"
+                    )
+                prev_name = name
+            continue
+
+        # Unknown line types
+        if len(line) >= 2 and line[1] == ":":
+            result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+        else:
+            result.error(
+                f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+            )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/names.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                     # Validate the file
+  %(prog)s --validate lib/edit/names.txt  # Validate a specific file
+  %(prog)s --export-json                  # Export to JSON (stdout)
+  %(prog)s --export-json > names.json     # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to names.txt file (default: lib/edit/names.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the names.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all name records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(names_file: Path) -> int:
+    """Run validation on the names file."""
+    print("=" * 60)
+    print(f"Validating: {names_file}")
+
+    # Validate the file
+    result = validate_names_file(names_file)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(names_file: Path) -> int:
+    """Export names to JSON on stdout."""
+    names = parse_names(names_file)
+
+    if not names:
+        print(f"ERROR: No names found in {names_file}", file=sys.stderr)
+        return 1
+
+    print(export_names_to_json(names))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        names_file = file_arg
+    else:
+        names_file = project_dir / "lib" / "edit" / "names.txt"
+
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(names_file)
+
+    if export_json:
+        return run_export_json(names_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-names.py
+++ b/bin/data-names.py
@@ -57,7 +57,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-object.py
+++ b/bin/data-object.py
@@ -36,13 +36,37 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import cast
 
-# JSON-compatible types
-type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
-type JsonDict = dict[str, JsonValue]
-
 # Handle broken pipe (e.g., when piping to head) - Unix only
 if hasattr(signal, "SIGPIPE"):
     _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+###
+### Valid colors per the documented specification (16 colors)
+###
+# D - Dark Gray    w - White          s - Gray          o - Orange
+# r - Red          g - Green          b - Blue          u - Brown
+# d - flavored     W - Light Gray     v - Violet        y - Yellow
+# R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
+#
+# Note: The actual file also uses extended colors with numeric suffixes
+# (e.g., s1, U1, D1) which are not documented in the comment section.
+VALID_BASE_COLORS = {"D", "w", "s", "o", "r", "g", "b", "u", "d", "W", "v", "y", "R", "G", "B", "U"}
+# Extended colors observed in actual data (base color + numeric suffix)
+VALID_EXTENDED_COLORS = {"D1", "g1", "s1", "U1", "v1", "W1", "y1"}
+VALID_COLORS = VALID_BASE_COLORS | VALID_EXTENDED_COLORS
+
+###
+### Regex patterns for validation
+###
+DICE_PATTERN = re.compile(r"^\d+d\d+$")
+# Allocation format: depth/rarity pairs
+ALLOCATION_PATTERN = re.compile(r"^\d+/\d+$")
+# Ability format: skill_id/ability_id
+ABILITY_PATTERN = re.compile(r"^\d+/\d+$")
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
 
 
 @dataclass
@@ -63,28 +87,6 @@ class ValidationResult:
     @property
     def is_valid(self) -> bool:
         return len(self.errors) == 0
-
-
-# Valid colors per the documented specification (16 colors):
-# D - Dark Gray    w - White          s - Gray          o - Orange
-# r - Red          g - Green          b - Blue          u - Brown
-# d - flavored     W - Light Gray     v - Violet        y - Yellow
-# R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
-#
-# Note: The actual file also uses extended colors with numeric suffixes
-# (e.g., s1, U1, D1) which are not documented in the comment section.
-DOCUMENTED_COLORS = {"D", "w", "s", "o", "r", "g", "b", "u", "d", "W", "v", "y", "R", "G", "B", "U"}
-EXTENDED_COLORS = {"D1", "g1", "s1", "U1", "v1", "W1", "y1"}
-VALID_COLORS = DOCUMENTED_COLORS | EXTENDED_COLORS
-
-###
-### Regex patterns for validation
-###
-DICE_PATTERN = re.compile(r"^\d+d\d+$")
-# Allocation format: depth/rarity pairs
-ALLOCATION_PATTERN = re.compile(r"^\d+/\d+$")
-# Ability format: skill_id/ability_id
-ABILITY_PATTERN = re.compile(r"^\d+/\d+$")
 
 
 @dataclass

--- a/bin/data-object.py
+++ b/bin/data-object.py
@@ -86,7 +86,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-race.py
+++ b/bin/data-race.py
@@ -62,7 +62,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-race.py
+++ b/bin/data-race.py
@@ -36,13 +36,13 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import cast
 
-# JSON-compatible types
-type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
-type JsonDict = dict[str, JsonValue]
-
 # Handle broken pipe (e.g., when piping to head) - Unix only
 if hasattr(signal, "SIGPIPE"):
     _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
 
 
 @dataclass

--- a/bin/data-special.py
+++ b/bin/data-special.py
@@ -34,13 +34,19 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import cast
 
-# JSON-compatible types
-type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
-type JsonDict = dict[str, JsonValue]
-
 # Handle broken pipe (e.g., when piping to head) - Unix only
 if hasattr(signal, "SIGPIPE"):
     _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+###
+### Regex patterns for validation
+###
+# Regex pattern for ability format
+ABILITY_PATTERN = re.compile(r"^\d+/\d+$")
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
 
 
 @dataclass
@@ -118,10 +124,6 @@ class Special:
     tval_ranges: list[TvalRange] = field(default_factory=list)
     abilities: list[AbilityRef] = field(default_factory=list)
     flags: list[str] = field(default_factory=list)
-
-
-# Regex pattern for ability format
-ABILITY_PATTERN = re.compile(r"^\d+/\d+$")
 
 
 def parse_limits_file(filepath: Path) -> Limits | None:

--- a/bin/data-special.py
+++ b/bin/data-special.py
@@ -66,7 +66,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-terrain.py
+++ b/bin/data-terrain.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the terrain.txt data file.
+
+1. Validates the format and integrity of lib/edit/terrain.txt.
+2. Exports the terrain records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: serial number : terrain name
+- G: symbol : color
+- M: feature to mimic
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import signal
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+###
+### Valid colors
+###
+# Valid base colors (16 colors)
+# D - Dark Gray    w - White          s - Gray          o - Orange
+# r - Red          g - Green          b - Blue          u - Brown
+# d - Black        W - Light Gray     v - Violet        y - Yellow
+# R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
+VALID_BASE_COLORS = set("DwsorgbudWvyRGBU")
+# Extended colors observed in actual data (base color + numeric suffix)
+VALID_EXTENDED_COLORS = {"G1", "v1", "B1", "U1", "D1", "W1", "y1"}
+VALID_COLORS = VALID_BASE_COLORS | VALID_EXTENDED_COLORS
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limits:
+    """Limits parsed from lib/edit/limits.txt."""
+
+    max_terrain_features: int  # M:F value
+
+    @property
+    def max_terrain_id(self) -> int:
+        """Maximum valid terrain ID (0-indexed, so max_terrain_features - 1)."""
+        return self.max_terrain_features - 1
+
+
+@dataclass
+class Terrain:
+    """A terrain record parsed from terrain.txt."""
+
+    id: int
+    name: str
+    symbol: str | None = None
+    color: str | None = None
+    mimic: int | None = None
+
+
+def parse_limits_file(filepath: Path) -> Limits | None:
+    """Parse limits.txt and extract relevant limits.
+
+    Returns None if the file cannot be parsed.
+    """
+    if not filepath.exists():
+        return None
+
+    max_terrain_features = None
+
+    for line in filepath.read_text(encoding="latin-1").splitlines():
+        line = line.strip()
+        if line.startswith("M:F:"):
+            # M:F:86 - Maximum number of terrain features
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[2].isdigit():
+                max_terrain_features = int(parts[2])
+
+    if max_terrain_features is None:
+        return None
+
+    return Limits(max_terrain_features=max_terrain_features)
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> int | None:
+    """Validate N: line format and return the ID."""
+    parts = line.split(":")
+    if len(parts) < 3:
+        result.error(f"Line {lineno}: N: line has {len(parts)} fields, expected at least 3: {line}")
+        return None
+
+    id_str = parts[1]
+    if not id_str.isdigit():
+        result.error(f"Line {lineno}: N: ID is not numeric: {id_str}")
+        return None
+
+    return int(id_str)
+
+
+def validate_g_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate G: line format (symbol : color).
+
+    Note: The symbol can be a colon itself, so G:::s means symbol=':' color='s'.
+    """
+    # Handle special case where symbol is a colon: G:::color
+    if line.startswith("G::"):
+        # Symbol is ':', color is everything after the third colon
+        if len(line) >= 4 and line[3] == ":":
+            color = line[4:]
+        else:
+            result.error(f"Line {lineno}: G: malformed line with colon symbol: {line}")
+            return
+    else:
+        parts = line.split(":")
+        if len(parts) != 3:
+            result.error(f"Line {lineno}: G: line has {len(parts)} fields, expected 3: {line}")
+            return
+        color = parts[2]
+
+    if color not in VALID_COLORS:
+        result.error(f"Line {lineno}: G: unrecognized color '{color}'")
+
+
+def validate_m_line(line: str, lineno: int, result: ValidationResult) -> None:
+    """Validate M: line format (feature to mimic)."""
+    parts = line.split(":")
+    if len(parts) != 2:
+        result.error(f"Line {lineno}: M: line has {len(parts)} fields, expected 2: {line}")
+        return
+
+    mimic_str = parts[1]
+    if not mimic_str.isdigit():
+        result.error(f"Line {lineno}: M: mimic ID is not numeric: {mimic_str}")
+
+
+def parse_terrains(filepath: Path) -> list[Terrain]:
+    """Parse terrain.txt and return a list of Terrain objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    terrains: list[Terrain] = []
+    current_terrain: Terrain | None = None
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#") or line.startswith("V:"):
+            continue
+
+        # N: line - start of new terrain
+        if line.startswith("N:"):
+            # Save previous terrain
+            if current_terrain is not None:
+                terrains.append(current_terrain)
+
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[1].isdigit():
+                current_terrain = Terrain(id=int(parts[1]), name=parts[2])
+            continue
+
+        if current_terrain is None:
+            continue
+
+        # G: symbol : color
+        # Note: Symbol can be a colon, so G:::s means symbol=':' color='s'
+        if line.startswith("G:"):
+            if line.startswith("G::") and len(line) >= 4 and line[3] == ":":
+                # Symbol is ':'
+                current_terrain.symbol = ":"
+                current_terrain.color = line[4:]
+            else:
+                parts = line.split(":")
+                if len(parts) >= 3:
+                    current_terrain.symbol = parts[1]
+                    current_terrain.color = parts[2]
+
+        # M: mimic
+        elif line.startswith("M:"):
+            parts = line.split(":")
+            if len(parts) >= 2 and parts[1].isdigit():
+                current_terrain.mimic = int(parts[1])
+
+    if current_terrain is not None:
+        terrains.append(current_terrain)
+
+    return terrains
+
+
+def export_terrains_to_json(terrains: list[Terrain]) -> str:
+    """Export terrains to a JSON string."""
+
+    def clean_dict(d: JsonDict) -> JsonDict:
+        """Recursively remove None values and empty collections from a dict."""
+        result: JsonDict = {}
+        for k, v in d.items():
+            if v is None or v == [] or v == "":
+                continue
+            if isinstance(v, dict):
+                cleaned = clean_dict(v)
+                if cleaned:  # Only include non-empty dicts
+                    result[k] = cleaned
+            elif isinstance(v, list):
+                # Clean each item if it's a dict
+                cleaned_list: list[JsonValue] = []
+                for item in v:
+                    if isinstance(item, dict):
+                        cleaned_item = clean_dict(item)
+                        if cleaned_item:
+                            cleaned_list.append(cleaned_item)
+                    elif item is not None:
+                        cleaned_list.append(item)
+                if cleaned_list:
+                    result[k] = cleaned_list
+            else:
+                result[k] = v
+        return result
+
+    def terrain_to_dict(terrain: Terrain) -> JsonDict:
+        """Convert a Terrain to a dict, removing None values."""
+        return clean_dict(asdict(terrain))
+
+    data = {"terrains": [terrain_to_dict(t) for t in terrains]}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_terrain_file(filepath: Path, limits: Limits | None = None) -> ValidationResult:
+    """Validate the entire terrain.txt file.
+
+    Args:
+        filepath: Path to terrain.txt file.
+        limits: Optional limits from limits.txt. If provided, validates
+                terrain count and IDs against the maximum allowed.
+    """
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"Terrain file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state. Maps id -> line number.
+    ids_seen: dict[int, int] = {}
+
+    prev_id = -1
+    has_version = False
+
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            continue
+
+        # Version stamp
+        if line.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line - start of terrain entry
+        if line.startswith("N:"):
+            terrain_id = validate_n_line(line, lineno, result)
+            if terrain_id is not None:
+                # Check for duplicates
+                if terrain_id in ids_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate ID {terrain_id} "
+                        + f"(first seen at line {ids_seen[terrain_id]})"
+                    )
+                else:
+                    ids_seen[terrain_id] = lineno
+
+                # Check IDs are increasing
+                if terrain_id <= prev_id:
+                    result.error(
+                        f"Line {lineno}: ID {terrain_id} is not greater than previous ID {prev_id} "
+                        + "(IDs must be strictly increasing)"
+                    )
+                prev_id = terrain_id
+
+                # Check ID against limit
+                if limits and terrain_id > limits.max_terrain_id:
+                    result.error(
+                        f"Line {lineno}: Terrain ID {terrain_id} exceeds maximum allowed ID "
+                        + f"{limits.max_terrain_id} (from limits.txt M:F:{limits.max_terrain_features})"
+                    )
+            continue
+
+        # Other line types
+        if line.startswith("G:"):
+            validate_g_line(line, lineno, result)
+        elif line.startswith("M:"):
+            validate_m_line(line, lineno, result)
+        else:
+            # Check for unknown line types (letter followed by colon)
+            if len(line) >= 2 and line[1] == ":":
+                result.error(f"Line {lineno}: Unknown line type '{line[0]}:' in line '{line}'")
+            else:
+                result.error(
+                    f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{line}'"
+                )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check total terrain count against limit
+    if limits:
+        terrain_count = len(ids_seen)
+        if terrain_count > limits.max_terrain_features:
+            result.error(
+                f"Total terrain count ({terrain_count}) exceeds maximum allowed "
+                + f"({limits.max_terrain_features}) from limits.txt M:F"
+            )
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/terrain.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                       # Validate the file
+  %(prog)s --validate lib/edit/terrain.txt  # Validate a specific file
+  %(prog)s --export-json                    # Export to JSON (stdout)
+  %(prog)s --export-json > terrains.json    # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to terrain.txt file (default: lib/edit/terrain.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the terrain.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all terrain records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(terrain_file: Path, limits_file: Path) -> int:
+    """Run validation on the terrain file."""
+    print("=" * 60)
+    print(f"Validating: {terrain_file}")
+
+    # Parse limits file
+    limits = parse_limits_file(limits_file)
+    if limits:
+        print(f"Limits: max terrain features = {limits.max_terrain_features} (max ID = {limits.max_terrain_id})")
+    else:
+        print(f"WARNING: Could not parse limits from {limits_file}", file=sys.stderr)
+
+    # Validate the file
+    result = validate_terrain_file(terrain_file, limits)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(terrain_file: Path) -> int:
+    """Export terrains to JSON on stdout."""
+    terrains = parse_terrains(terrain_file)
+
+    if not terrains:
+        print(f"ERROR: No terrains found in {terrain_file}", file=sys.stderr)
+        return 1
+
+    print(export_terrains_to_json(terrains))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        terrain_file = file_arg
+    else:
+        terrain_file = project_dir / "lib" / "edit" / "terrain.txt"
+
+    limits_file = project_dir / "lib" / "edit" / "limits.txt"
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(terrain_file, limits_file)
+
+    if export_json:
+        return run_export_json(terrain_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-terrain.py
+++ b/bin/data-terrain.py
@@ -68,7 +68,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-vault.py
+++ b/bin/data-vault.py
@@ -75,7 +75,7 @@ class ValidationResult:
 
     @property
     def is_valid(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
 
 @dataclass

--- a/bin/data-vault.py
+++ b/bin/data-vault.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Provides tooling for the vault.txt data file.
+
+1. Validates the format and integrity of lib/edit/vault.txt.
+2. Exports the vault records to JSON format (stdout).
+
+Data Validation
+===============
+
+Based on the format specification in the file's comment header:
+- N: serial number : vault name
+- X: room type : depth : rarity [: rows : columns]
+- F: flag1 | flag2 | ...
+- D: layout line (ASCII art defining the vault layout)
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validation errors found
+"""
+
+import argparse
+import json
+import signal
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+# Handle broken pipe (e.g., when piping to head) - Unix only
+if hasattr(signal, "SIGPIPE"):
+    _ = signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# JSON-compatible types
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonDict = dict[str, JsonValue]
+
+# Valid vault flags
+VALID_FLAGS = {
+    "TEST",
+    "NO_ROTATION",
+    "TRAPS",
+    "WEBS",
+    "LIGHT",
+    "SURFACE",
+}
+
+# Valid room types
+VALID_ROOM_TYPES = {
+    6,   # interesting room
+    7,   # lesser vault
+    8,   # greater vault
+    9,   # Morgoth's vault
+    10,  # Gates of Angband
+}
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def log_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class Limits:
+    """Limits parsed from lib/edit/limits.txt."""
+
+    max_vaults: int  # M:V value
+
+    @property
+    def max_vault_id(self) -> int:
+        """Maximum valid vault ID (0-indexed, so max_vaults - 1)."""
+        return self.max_vaults - 1
+
+
+@dataclass
+class Vault:
+    """A vault record parsed from vault.txt."""
+
+    id: int
+    name: str
+    room_type: int | None = None
+    depth: int | None = None
+    rarity: int | None = None
+    rows: int | None = None
+    columns: int | None = None
+    flags: list[str] = field(default_factory=list)
+    layout: list[str] = field(default_factory=list)
+
+
+def parse_limits_file(filepath: Path) -> Limits | None:
+    """Parse limits.txt and extract relevant limits.
+
+    Returns None if the file cannot be parsed.
+    """
+    if not filepath.exists():
+        return None
+
+    max_vaults = None
+
+    for line in filepath.read_text(encoding="latin-1").splitlines():
+        line = line.strip()
+        if line.startswith("M:V:"):
+            # M:V:500 - Maximum number of vaults
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[2].isdigit():
+                max_vaults = int(parts[2])
+
+    if max_vaults is None:
+        return None
+
+    return Limits(max_vaults=max_vaults)
+
+
+def validate_n_line(line: str, lineno: int, result: ValidationResult) -> int | None:
+    """Validate N: line format and return the ID."""
+    parts = line.split(":")
+    if len(parts) < 3:
+        result.error(f"Line {lineno}: N: line has {len(parts)} fields, expected at least 3: {line}")
+        return None
+
+    id_str = parts[1]
+    if not id_str.isdigit():
+        result.error(f"Line {lineno}: N: serial number is not numeric: {id_str}")
+        return None
+
+    return int(id_str)
+
+
+def validate_x_line(line: str, lineno: int, result: ValidationResult) -> tuple[int, int, int, int | None, int | None] | None:
+    """Validate X: line format and return (type, depth, rarity, rows, columns)."""
+    parts = line.split(":")
+    # X:type:depth:rarity or X:type:depth:rarity:rows:columns
+    if len(parts) < 4:
+        result.error(f"Line {lineno}: X: line has {len(parts)} fields, expected at least 4: {line}")
+        return None
+
+    # Validate type
+    type_str = parts[1]
+    if not type_str.isdigit():
+        result.error(f"Line {lineno}: X: room type is not numeric: {type_str}")
+        return None
+    room_type = int(type_str)
+    if room_type not in VALID_ROOM_TYPES:
+        result.warning(f"Line {lineno}: X: unknown room type {room_type}")
+
+    # Validate depth
+    depth_str = parts[2]
+    if not depth_str.isdigit():
+        result.error(f"Line {lineno}: X: depth is not numeric: {depth_str}")
+        return None
+    depth = int(depth_str)
+
+    # Validate rarity
+    rarity_str = parts[3]
+    if not rarity_str.isdigit():
+        result.error(f"Line {lineno}: X: rarity is not numeric: {rarity_str}")
+        return None
+    rarity = int(rarity_str)
+
+    rows: int | None = None
+    columns: int | None = None
+
+    # Optional rows and columns
+    if len(parts) >= 5:
+        rows_str = parts[4]
+        if rows_str and not rows_str.isdigit():
+            result.error(f"Line {lineno}: X: rows is not numeric: {rows_str}")
+            return None
+        if rows_str:
+            rows = int(rows_str)
+
+    if len(parts) >= 6:
+        cols_str = parts[5]
+        if cols_str and not cols_str.isdigit():
+            result.error(f"Line {lineno}: X: columns is not numeric: {cols_str}")
+            return None
+        if cols_str:
+            columns = int(cols_str)
+
+    return (room_type, depth, rarity, rows, columns)
+
+
+def validate_f_line(line: str, lineno: int, result: ValidationResult) -> list[str]:
+    """Validate F: line format and return list of flags."""
+    content = line[2:].strip()
+    if not content:
+        return []
+
+    # Flags can be separated by | or spaces
+    if "|" in content:
+        flags = [f.strip() for f in content.split("|") if f.strip()]
+    else:
+        flags = content.split()
+
+    for flag in flags:
+        if flag not in VALID_FLAGS:
+            result.warning(f"Line {lineno}: F: unknown flag '{flag}'")
+
+    return flags
+
+
+def validate_layout_dimensions(
+    vault_id: int,
+    vault_name: str,
+    expected_rows: int | None,
+    expected_cols: int | None,
+    layout: list[str],
+    layout_start_line: int,
+    result: ValidationResult,
+) -> None:
+    """Validate that layout dimensions match X: line specifications."""
+    if not layout:
+        return
+
+    actual_rows = len(layout)
+    actual_cols = max(len(line) for line in layout) if layout else 0
+
+    if expected_rows is not None and actual_rows != expected_rows:
+        result.error(
+            f"Vault {vault_id} ({vault_name}): layout has {actual_rows} rows, "
+            f"expected {expected_rows} from X: line"
+        )
+
+    if expected_cols is not None and actual_cols != expected_cols:
+        result.error(
+            f"Vault {vault_id} ({vault_name}): layout has max {actual_cols} columns, "
+            f"expected {expected_cols} from X: line"
+        )
+
+
+def parse_vaults(filepath: Path) -> list[Vault]:
+    """Parse vault.txt and return a list of Vault objects."""
+    if not filepath.exists():
+        return []
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+    vaults: list[Vault] = []
+    current_vault: Vault | None = None
+
+    for line in lines:
+        # Don't strip - preserve whitespace for D: lines
+        stripped = line.strip()
+
+        # Skip empty lines and comments
+        if not stripped or stripped.startswith("#") or stripped.startswith("V:"):
+            continue
+
+        # N: line - start of new vault
+        if stripped.startswith("N:"):
+            # Save previous vault
+            if current_vault is not None:
+                vaults.append(current_vault)
+
+            parts = stripped.split(":")
+            if len(parts) >= 3 and parts[1].isdigit():
+                current_vault = Vault(id=int(parts[1]), name=":".join(parts[2:]))
+            continue
+
+        if current_vault is None:
+            continue
+
+        # X: line
+        if stripped.startswith("X:"):
+            parts = stripped.split(":")
+            if len(parts) >= 4:
+                try:
+                    current_vault.room_type = int(parts[1])
+                    current_vault.depth = int(parts[2])
+                    current_vault.rarity = int(parts[3])
+                    if len(parts) >= 5 and parts[4]:
+                        current_vault.rows = int(parts[4])
+                    if len(parts) >= 6 and parts[5]:
+                        current_vault.columns = int(parts[5])
+                except ValueError:
+                    pass
+
+        # F: flags
+        elif stripped.startswith("F:"):
+            content = stripped[2:].strip()
+            if "|" in content:
+                current_vault.flags = [f.strip() for f in content.split("|") if f.strip()]
+            else:
+                current_vault.flags = content.split()
+
+        # D: layout line - preserve exact content after "D:"
+        elif stripped.startswith("D:"):
+            # Use original line to preserve whitespace, just remove "D:" prefix
+            if line.startswith("D:"):
+                current_vault.layout.append(line[2:])
+            else:
+                # Handle case where line might have leading whitespace before D:
+                idx = line.index("D:")
+                current_vault.layout.append(line[idx + 2:])
+
+    if current_vault is not None:
+        vaults.append(current_vault)
+
+    return vaults
+
+
+def export_vaults_to_json(vaults: list[Vault]) -> str:
+    """Export vaults to a JSON string, preserving exact layout whitespace."""
+
+    def vault_to_dict(vault: Vault) -> JsonDict:
+        """Convert a Vault to a dict."""
+        d: JsonDict = {
+            "id": vault.id,
+            "name": vault.name,
+        }
+        if vault.room_type is not None:
+            d["room_type"] = vault.room_type
+        if vault.depth is not None:
+            d["depth"] = vault.depth
+        if vault.rarity is not None:
+            d["rarity"] = vault.rarity
+        if vault.rows is not None:
+            d["rows"] = vault.rows
+        if vault.columns is not None:
+            d["columns"] = vault.columns
+        if vault.flags:
+            d["flags"] = vault.flags
+        if vault.layout:
+            d["layout"] = vault.layout
+        return d
+
+    data = {"vaults": [vault_to_dict(v) for v in vaults]}
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def validate_vault_file(filepath: Path, limits: Limits | None = None) -> ValidationResult:
+    """Validate the entire vault.txt file.
+
+    Args:
+        filepath: Path to vault.txt file.
+        limits: Optional limits from limits.txt.
+    """
+    result = ValidationResult()
+
+    if not filepath.exists():
+        result.error(f"Vault file not found: {filepath}")
+        return result
+
+    lines = filepath.read_text(encoding="latin-1").splitlines()
+
+    # Track state
+    ids_seen: dict[int, int] = {}  # Maps id -> line number
+    prev_id = -1
+    has_version = False
+
+    # Current vault tracking for layout validation
+    current_vault_id: int | None = None
+    current_vault_name: str = ""
+    current_expected_rows: int | None = None
+    current_expected_cols: int | None = None
+    current_layout: list[str] = []
+    current_layout_start: int = 0
+
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        # Skip empty lines and comments
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        # Version stamp
+        if stripped.startswith("V:"):
+            has_version = True
+            continue
+
+        # N: line - start of vault entry
+        if stripped.startswith("N:"):
+            # Validate previous vault's layout dimensions
+            if current_vault_id is not None and current_layout:
+                validate_layout_dimensions(
+                    current_vault_id,
+                    current_vault_name,
+                    current_expected_rows,
+                    current_expected_cols,
+                    current_layout,
+                    current_layout_start,
+                    result,
+                )
+
+            vault_id = validate_n_line(stripped, lineno, result)
+            if vault_id is not None:
+                # Check for duplicates
+                if vault_id in ids_seen:
+                    result.error(
+                        f"Line {lineno}: Duplicate ID {vault_id} "
+                        + f"(first seen at line {ids_seen[vault_id]})"
+                    )
+                else:
+                    ids_seen[vault_id] = lineno
+
+                # Check IDs are increasing
+                if vault_id <= prev_id:
+                    result.warning(
+                        f"Line {lineno}: ID {vault_id} is not greater than previous ID {prev_id}"
+                    )
+                prev_id = vault_id
+
+                # Check ID against limit
+                if limits and vault_id > limits.max_vault_id:
+                    result.error(
+                        f"Line {lineno}: Vault ID {vault_id} exceeds maximum allowed ID "
+                        + f"{limits.max_vault_id} (from limits.txt M:V:{limits.max_vaults})"
+                    )
+
+                # Reset for new vault
+                current_vault_id = vault_id
+                parts = stripped.split(":")
+                current_vault_name = ":".join(parts[2:]) if len(parts) >= 3 else ""
+                current_expected_rows = None
+                current_expected_cols = None
+                current_layout = []
+                current_layout_start = 0
+            continue
+
+        # X: line
+        if stripped.startswith("X:"):
+            parsed = validate_x_line(stripped, lineno, result)
+            if parsed:
+                _, _, _, rows, cols = parsed
+                current_expected_rows = rows
+                current_expected_cols = cols
+            continue
+
+        # F: line
+        if stripped.startswith("F:"):
+            _ = validate_f_line(stripped, lineno, result)
+            continue
+
+        # D: line
+        if stripped.startswith("D:"):
+            if not current_layout:
+                current_layout_start = lineno
+            # Preserve exact content after D:
+            if line.startswith("D:"):
+                current_layout.append(line[2:])
+            else:
+                idx = line.index("D:")
+                current_layout.append(line[idx + 2:])
+            continue
+
+        # Unknown line types
+        if len(stripped) >= 2 and stripped[1] == ":":
+            result.error(f"Line {lineno}: Unknown line type '{stripped[0]}:' in line '{stripped}'")
+        else:
+            result.error(
+                f"Line {lineno}: Unrecognized line (missing '#' comment marker?): '{stripped}'"
+            )
+
+    # Validate last vault's layout
+    if current_vault_id is not None and current_layout:
+        validate_layout_dimensions(
+            current_vault_id,
+            current_vault_name,
+            current_expected_rows,
+            current_expected_cols,
+            current_layout,
+            current_layout_start,
+            result,
+        )
+
+    # Check for required version stamp
+    if not has_version:
+        result.error("Missing required version stamp (V: line)")
+
+    # Check total vault count against limit
+    if limits:
+        vault_count = len(ids_seen)
+        if vault_count > limits.max_vaults:
+            result.error(
+                f"Total vault count ({vault_count}) exceeds maximum allowed "
+                + f"({limits.max_vaults}) from limits.txt M:V"
+            )
+
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Work with lib/edit/vault.txt data files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --validate                     # Validate the file
+  %(prog)s --validate lib/edit/vault.txt  # Validate a specific file
+  %(prog)s --export-json                  # Export to JSON (stdout)
+  %(prog)s --export-json > vaults.json    # Export to JSON file
+""",
+    )
+    _ = parser.add_argument(
+        "file",
+        nargs="?",
+        type=Path,
+        help="Path to vault.txt file (default: lib/edit/vault.txt)",
+    )
+    _ = parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the vault.txt file format and integrity",
+    )
+    _ = parser.add_argument(
+        "--export-json",
+        action="store_true",
+        help="Export all vault records to JSON (stdout)",
+    )
+    return parser.parse_args()
+
+
+def run_validation(vault_file: Path, limits_file: Path) -> int:
+    """Run validation on the vault file."""
+    print("=" * 60)
+    print(f"Validating: {vault_file}")
+
+    # Parse limits file
+    limits = parse_limits_file(limits_file)
+    if limits:
+        print(f"Limits: max vaults = {limits.max_vaults} (max ID = {limits.max_vault_id})")
+    else:
+        print(f"WARNING: Could not parse limits from {limits_file}", file=sys.stderr)
+
+    # Validate the file
+    result = validate_vault_file(vault_file, limits)
+
+    # Print all messages of the validation result
+    for msg in result.info:
+        print(f"INFO: {msg}")
+
+    for msg in result.warnings:
+        print(f"WARNING: {msg}", file=sys.stderr)
+
+    for msg in result.errors:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+    # Summary
+    print("=" * 60)
+    print(f"  Errors:   {len(result.errors)}")
+    print(f"  Warnings: {len(result.warnings)}")
+    print("=" * 60)
+
+    if result.is_valid:
+        print("OK")
+    else:
+        print("FAILED")
+
+    return 0 if result.is_valid else 1
+
+
+def run_export_json(vault_file: Path) -> int:
+    """Export vaults to JSON on stdout."""
+    vaults = parse_vaults(vault_file)
+
+    if not vaults:
+        print(f"ERROR: No vaults found in {vault_file}", file=sys.stderr)
+        return 1
+
+    print(export_vaults_to_json(vaults))
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Determine file paths
+    file_arg = cast(Path | None, args.file)
+    script_dir = Path(__file__).resolve().parent
+    project_dir = script_dir.parent
+
+    if file_arg:
+        vault_file = file_arg
+    else:
+        vault_file = project_dir / "lib" / "edit" / "vault.txt"
+
+    limits_file = project_dir / "lib" / "edit" / "limits.txt"
+    validate = cast(bool, args.validate)
+    export_json = cast(bool, args.export_json)
+
+    if validate:
+        return run_validation(vault_file, limits_file)
+
+    if export_json:
+        return run_export_json(vault_file)
+
+    # No action specified
+    print("No action specified. Use --validate or --export-json.", file=sys.stderr)
+    print("Run with --help for more information.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        sys.exit(0)

--- a/bin/data-vault.py
+++ b/bin/data-vault.py
@@ -231,7 +231,17 @@ def validate_layout_dimensions(
         return
 
     actual_rows = len(layout)
-    actual_cols = max(len(line) for line in layout) if layout else 0
+    line_widths = [len(line) for line in layout]
+    actual_cols = max(line_widths) if line_widths else 0
+
+    # Check that all D: lines have consistent width
+    if len(set(line_widths)) > 1:
+        min_width = min(line_widths)
+        max_width = max(line_widths)
+        result.error(
+            f"Vault {vault_id} ({vault_name}): layout has inconsistent line widths "
+            f"(min={min_width}, max={max_width})"
+        )
 
     if expected_rows is not None and actual_rows != expected_rows:
         result.error(

--- a/bin/python-lint
+++ b/bin/python-lint
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Lint the Python sources.
+#
+
+# shellcheck disable=SC2068
+uv run ruff check $@

--- a/lib/docs/CHANGELOG.md
+++ b/lib/docs/CHANGELOG.md
@@ -104,6 +104,7 @@ Changed:
 
 Fixed:
 
+- fix: use `F:` for feature flags of The Leather Armour of Haldad
 - Fix inconsistent house naming for Falathrim and Haleth (fixes #164)
   ([#173](https://github.com/sil-quirk/sil-q/pull/173))
   - thanks @imraflip

--- a/lib/edit/ability.txt
+++ b/lib/edit/ability.txt
@@ -1,18 +1,19 @@
 # File: ability.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/ability.raw` file, which is
 # used to initialize the "ability" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding ability.txt ===

--- a/lib/edit/ability.txt
+++ b/lib/edit/ability.txt
@@ -1,17 +1,17 @@
 # File: ability.txt
 #
-# This file is used to create the "lib/data/ability.raw" file, which is
+# This file is used to create the `lib/data/ability.raw` file, which is
 # used to initialize the "ability" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
 #
 # === Understanding ability.txt ===
 #
 # N: ability number : ability name
 # I: skill number : ability value : level requirement
 # P: prerequisite skill number / prerequisite ability value : ...
+# T: tval : sval_min : sval_max
 # D: description
 #
 # 'N' indicates the beginning of an entry. The serial number must
@@ -22,15 +22,20 @@
 #
 # 'P' is the prerequisite abilities if any
 #
+# 'T' is the item type range that can have this ability granted.
+#     tval is the item type value (e.g., 21=hafted, 22=polearms, 23=swords).
+#     sval_min and sval_max define the subtype range (0:99 means all subtypes).
+#
 # 'D' is a textual description of the ability
-
 
 
 # Version stamp (required)
 
 V:1.5.1
 
-# Melee ---------------------------------------------
+###############################################################################
+# Melee
+###############################################################################
 
 N:0:Power
 I:0:0:1
@@ -165,7 +170,9 @@ I:0:13:20
 D:You gain a point of strength.
 
 
-# Archery ---------------------------------------------
+###############################################################################
+# Archery
+###############################################################################
 
 N:20:Rout
 I:1:0:2
@@ -228,7 +235,10 @@ N:28:Dexterity
 I:1:8:10
 D:You gain a point of dexterity.
 
-# Evasion ---------------------------------------------
+
+###############################################################################
+# Evasion
+###############################################################################
 
 N:40:Dodging
 I:2:0:2
@@ -242,7 +252,7 @@ T:45:0:99  # Ring
 N:41:Blocking
 I:2:1:3
 D:Doubles the protection roll for your shield against all attacks
-D: if you did not move on your last turn. 
+D: if you did not move on your last turn.
 T:34:0:99  # Shields
 
 N:42:Parry
@@ -317,7 +327,10 @@ N:50:Dexterity
 I:2:10:20
 D:You gain a point of dexterity.
 
-# Stealth ---------------------------------------------
+
+###############################################################################
+# Stealth
+###############################################################################
 
 N:60:Disguise
 I:3:0:3
@@ -381,7 +394,10 @@ P:3/0:3/1
 I:3:6:11
 D:You gain a point of dexterity.
 
-# Perception ---------------------------------------------
+
+###############################################################################
+# Perception
+###############################################################################
 
 N:80:Quick Study
 I:4:0:1
@@ -456,7 +472,10 @@ N:89:Grace
 I:4:9:10
 D:You gain a point of grace.
 
-# Will ---------------------------------------------
+
+###############################################################################
+# Will
+###############################################################################
 
 N:100:Curse Breaking
 I:5:0:1
@@ -469,7 +488,8 @@ T:34:0:99  # Shields
 
 N:101:Channeling
 I:5:1:2
-D:You automatically recognise all staves and horns and can use them twice as efficiently.
+D:You automatically recognise all staves and horns and can use them twice as
+D: efficiently.
 T:32:0:99  # Helm
 T:45:0:99  # Ring
 
@@ -537,7 +557,10 @@ N:110:Constitution
 I:5:10:12
 D:You gain a point of constitution.
 
-# Smithing ---------------------------------------------
+
+###############################################################################
+# Smithing
+###############################################################################
 
 N:120:Weaponsmith
 I:6:0:2
@@ -592,7 +615,10 @@ N:127:Grace
 I:6:7:10
 D:You gain a point of grace.
 
-# Song ---------------------------------------------
+
+###############################################################################
+# Song
+###############################################################################
 
 N:140:Song of Elbereth
 I:7:0:1
@@ -603,7 +629,7 @@ T:39:0:99  # Light Source
 
 N:141:Song of Challenge
 I:7:1:1
-D:Causes weak-willed foes to attack aggressively without regard to 
+D:Causes weak-willed foes to attack aggressively without regard to
 D: strategy. Enemies with ranged weapons will close to melee range.
 T:32:0:99  # Helm
 T:21:0:99  # Hafted

--- a/lib/edit/ability.txt
+++ b/lib/edit/ability.txt
@@ -6,6 +6,15 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
+#
 # === Understanding ability.txt ===
 #
 # N: ability number : ability name

--- a/lib/edit/artefact.txt
+++ b/lib/edit/artefact.txt
@@ -1,11 +1,10 @@
 # File: artefact.txt
 #
-# This file is used to create the 'lib/data/artefact.raw' file, which
+# This file is used to create the `lib/data/artefact.raw` file, which
 # is used to initialize the 'artefact' information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
 #
 # === Understanding artefact.txt ===
 #
@@ -21,35 +20,39 @@
 # 'N' indicates the beginning of an entry. The serial number must
 #     increase for each new item.
 #
-# 'G' is for graphics overrides, if any. The char is the symbol 
-#     and the attr the colour. (See object.txt)
+# 'G' is for graphics overrides, if any. The char is the symbol and the attr
+#     the colour. Extended colors use a numeric suffix (e.g., b1).
+#     (See object.txt)
 #
 # 'I' is for basic information. The tval is for the type of item, the
 #     sval identifies the subtype and the pval indicates the amount of
 #     effect the item has, if applicable.
 #     (See object.txt)
 #
-# 'B' is for granted abilities, represented as pairs of skill 
-#     numbers and ability numbers. (See ability.txt)
+# 'B' is for granted abilities, represented as pairs of skill numbers and
+#     ability numbers. Multiple abilities are separated by colons (e.g.,
+#     B:6/3:6/6).
+#     (See ability.txt)
 #
 # 'W' is for extra information. Depth is the depth the object is
 #     normally found at, rarity determines how common the object is,
 #     weight is in tenth-pounds and cost is the item's value.
 #
 # 'P' is for power information. The item's bonuses to attack and
-#     evasion, as well as its damage and protection dice.
-#     Note that for non-weapons, adding damage dice will not
-#     help with melee, only with the thrown damage.
+#     evasion, as well as its damage and protection dice. Bonuses can
+#     have a + prefix (e.g., +2, +11). Some items (crowns) have a 5th
+#     value (always 0). Note that for non-weapons, adding damage dice
+#     will not help with melee, only with the thrown damage.
 #
-# 'F' is for flags. These are fairly self-explanatory. As many 
-#     F: lines may be used as are needed to specify all the flags
-#     and flags are separated by the '|' symbol.
+# 'F' is for flags. As many F: lines may be used as are needed to specify all
+#     the flags. Flags are separated by the '|' symbol.
 #
 # 'D' is a textual description of the artefact.
-# 
+#
+#
 # === Important Notes ===
 #
-# (1) The artefact indexes are defined in 'defines.h', and must not be changed.
+# (1) The artefact indexes are defined in `defines.h` and must not be changed.
 #
 # (2) Any changes or additions to the file will have influence on randarts
 #     and may break savefile compatibility for old savegames with randarts.  If
@@ -67,66 +70,65 @@
 #     or limits.txt.)
 #
 #
-#
 # === Ideas for Artefacts ===
 #
 # Regarding the dating and cut-offs for the items, Beren and Luthien stole a
 # Silmaril in FA 465, so I'd like to keep roughly to this date.
 #
 # Elves
-# * Feanor		(crown - smithing, fire, will, aggravate)
-#   * Maedhros		(hauberk - combat bonuses, res fire, res poison)
-#                       (crown - will, Majesty, res fear, danger)
-#   * Maglor		(cloak - song, restore voice)
-#   * Celegorm		(bow - will, slay wolf/spider)
-#   * Caranthir		(leather - stealth, dark, rage)
-#   * Curufin		(helm - perception, stealth, will, res confusion)
-#     * Celebrimbor	(gloves - expertise, free action)
-#   * Amrod		(short sword - perception, stealth)
-#   * Amras		
-# * Fingolfin		('ringil' - rcold, light) (shield - con, rfear)
-#   * Fingon		(corslet - resist fear, con)
-#     * Gil-galad	('aeglos' - cold)
-#   * Turgon		('glamdring' - will, slay orc/troll/rauko/dragon)
-#     * Idril		(robe - speed)	
-#       * Earendil	(elessar - con, regenerate, heal) (bow - dex, slay dragon)
-#   * Aredhel		(robe - sustain grace, free action, res dark)
-#     * Maeglin	        (galvorn armour - hunger, channelling, res poison)
+# * Feanor           (crown - smithing, fire, will, aggravate)
+#   * Maedhros       (hauberk - combat bonuses, res fire, res poison)
+#                    (crown - will, Majesty, res fear, danger)
+#   * Maglor         (cloak - song, restore voice)
+#   * Celegorm       (bow - will, slay wolf/spider)
+#   * Caranthir      (leather - stealth, dark, rage)
+#   * Curufin        (helm - perception, stealth, will, res confusion)
+#     * Celebrimbor  (gloves - expertise, free action)
+#   * Amrod          (short sword - perception, stealth)
+#   * Amras
+# * Fingolfin        ('ringil' - rcold, light) (shield - con, rfear)
+#   * Fingon         (corslet - resist fear, con)
+#     * Gil-galad    ('aeglos' - cold)
+#   * Turgon         ('glamdring' - will, slay orc/troll/rauko/dragon)
+#     * Idril        (robe - speed)
+#       * Earendil   (elessar - con, regenerate, heal) (bow - dex, slay dragon)
+#   * Aredhel        (robe - sustain grace, free action, res dark)
+#     * Maeglin      (galvorn armour - hunger, channelling, res poison)
 # - Finarfin
-#   * Finrod		(boots - good evasion, free action)
-#   * Angrod		(helm - res cold, res fear, regen)
-#     * Orodreth	(greaves - dex, res fire)
-#   * Aegnor		(armour - concentration)
+#   * Finrod         (boots - good evasion, free action)
+#   * Angrod         (helm - res cold, res fear, regen)
+#     * Orodreth     (greaves - dex, res fire)
+#   * Aegnor         (armour - concentration)
 #   * Galadriel
-# * Thingol		(cloak - grey, rfire, rcold, free act) (Aranruth - will, rfear, danger)
-#   * Luthien		(shadow cloak - res dark, sust gra, stealth)
+# * Thingol          (cloak - grey, rfire, rcold, free act) (Aranruth - will, rfear, danger)
+#   * Luthien        (shadow cloak - res dark, sust gra, stealth)
 # * also...
-#   * Daeron		(? - song, hunger)
+#   * Daeron         (? - song, hunger)
 #   - Celeborn
-#   * Beleg		(Dailir - bonuses) (Belthronding - dex, stealth, shot)
-#   * Eol		('Ang' - sharpness, danger) ('Ang' - sharpness, hunger)
+#   * Beleg          (Dailir - bonuses) (Belthronding - dex, stealth, shot)
+#   * Eol            ('Ang' - sharpness, danger) ('Ang' - sharpness, hunger)
 #   * Ecthelion
-#   * Tinfang Gelion	(? - song)
+#   * Tinfang Gelion (? - song)
 #
 # Men
-# * Beor		(studded leather - resist poison, resist dark)
-#   * Andreth           (robe - song, sust gra)
-#   * Beren		(dagmor - grace, res fear, res dark)
-#   * Barahir		(Ring - free action, res poison)
-#   * Bregolas		(Gauntlets - power, res cold)
-#   * Tuor		(Dramborleg - slay orc/troll/rauko)
+# * Beor             (studded leather - resist poison, resist dark)
+#   * Andreth        (robe - song, sust gra)
+#   * Beren          (dagmor - grace, res fear, res dark)
+#   * Barahir        (Ring - free action, res poison)
+#   * Bregolas       (Gauntlets - power, res cold)
+#   * Tuor           (Dramborleg - slay orc/troll/rauko)
 # - Marach
-#   * Hador		(shield - res cold, res lightning)
-#   * Hurin		(battle axe - con, will, resist fear, slay troll, rage)
-#     * Turin		(dragon helm - str, will, rfear, rstun) (Anglachel - sharp, danger)
+#   * Hador          (shield - res cold, res lightning)
+#   * Hurin          (battle axe - con, will, resist fear, slay troll, rage)
+#     * Turin        (dragon helm - str, will, rfear, rstun) (Anglachel - sharp, danger)
 #   - Gloredhel
-# * Halmir		(staff - sustain str/con, res poison)
-# * Haldad		(leather armour - str, free act, res fear)
+# * Halmir           (staff - sustain str/con, res poison)
+# * Haldad           (leather armour - str, free act, res fear)
 #
 # Dwarves
-# * Azaghal		(dagger - slay dragon, res fear, res fire)
-# * Durin		(mail corslet - res fire, res cold, regenerate)
-# * Telchar		(hammer - smithing, sust str, res fire)
+# * Azaghal          (dagger - slay dragon, res fear, res fire)
+# * Durin            (mail corslet - res fire, res cold, regenerate)
+# * Telchar          (hammer - smithing, sust str, res fire)
 #
 # Powers
 # * Melian
@@ -135,7 +137,7 @@
 # * Sirion
 # * Taur-nu-fuin
 # * Belegost
-# * Nogrod		(great axe - slay orc/troll/rauko, res fire)
+# * Nogrod           (great axe - slay orc/troll/rauko, res fire)
 # * Amon Rudh
 # - Taur-im-Duinath
 # * Nargothrond
@@ -150,20 +152,20 @@
 #
 # The Iron Helm of Vinyamar (Set Item)
 #
-#D:The helm left by Turgon in Vinyamar for the messenger of Ulmo.  Crowned by 
-#D:three swan's feathers, it greatens the heart and clarifies the purpose of 
-#D:the one who wears it.
+#D:The helm left by Turgon in Vinyamar for the messenger of Ulmo.  Crowned by
+#D: three swan's feathers, it greatens the heart and clarifies the purpose of
+#D: the one who wears it.
 #
 # Also, a Shadow Cloak of Ulmo could be added to complete the Vinyamar set
-
 
 
 # Version stamp (required)
 
 V:1.5.1
 
-#################################################################
-# Here is the list of 'Special' artefacts. 
+###############################################################################
+# 'Special' artefacts
+#
 # They can be:
 #   - Rings
 #   - Amulets
@@ -171,7 +173,7 @@ V:1.5.1
 #   - Crowns
 # Only artefacts 1 to 19 may be of these types.
 # Artefacts from index number 20 onwards must be Armour or Weapons.
-
+###############################################################################
 
 ## The Ring of Barahir
 ## 1st age
@@ -262,7 +264,7 @@ P:0:0d0:0:0d0
 F:CON | GRA
 F:INSTA_ART
 D:The Nauglamir; a carcanet of gold set with a multitude of shining gems
-D: of Valinor. It was made by the dwarves of Ered Luin for Finrod Felagund. 
+D: of Valinor. It was made by the dwarves of Ered Luin for Finrod Felagund.
 
 ## The Ring of Mairon
 ## (ability 3/5 is Vanish)
@@ -327,15 +329,16 @@ D: when he went to parley with him and hung by his right hand from Thangorodrim
 D: for thirty years.
 
 
-
-#################################################################
-# Here is the list of 'Normal' artefacts. 
+###############################################################################
+# 'Normal' artefacts
+#
 # They can be Armour or Weapons.
 # They use indices 20 - 139.
+###############################################################################
 
-
-##### Soft Armor #####
-
+###############################################################################
+# Soft Armor
+###############################################################################
 
 ## The Robe of Andreth
 ## 1st age
@@ -462,9 +465,9 @@ D: armour was wrought years ago by the master smith Eol,
 D: and given as a gift to his son, Maeglin.
 
 
-
-##### Hard Armor #####
-
+###############################################################################
+# Hard Armor
+###############################################################################
 
 ## The Mail Corslet of Fingon
 ## 1st age namesake
@@ -559,8 +562,9 @@ D: almost too small to see, that twinkle in torchlight just
 D: as the stars of Varda twinkle in the night sky.
 
 
-##### Shields #####
-
+###############################################################################
+# Shields
+###############################################################################
 
 ## The Round Shield of the Bloody Hand
 
@@ -657,7 +661,9 @@ D: Untarnished by long years waiting in Turgon's deserted halls of Vinyamar,
 D: it conveys the same powers of endurance to its bearer.
 
 
-##### Edged Weapons #####
+###############################################################################
+# Edged Weapons
+###############################################################################
 
 ## The Dagger of Nargil
 ## 1st age
@@ -692,15 +698,14 @@ W:14:4:5:100000
 P:0:1d5:0:0d0
 F:SHARPNESS2
 F:THROWING
-D:Forged from meteoric iron by Telchar, greatest of Dwarven smiths, 
+D:Forged from meteoric iron by Telchar, greatest of Dwarven smiths,
 D: this dagger slices through metal as easily as flesh, earning its
 D: name: 'Iron Cleaver'.
 
 
-#
-# The Curved Sword 'Nakh'
-# - added since there were no artefact curved blades
-#
+## The Curved Sword 'Nakh'
+## - added since there were no artefact curved blades
+
 N:55:'Nakh'
 I:23:7:2
 W:4:10:60:30000
@@ -710,10 +715,9 @@ D:A dread black blade greatly famed among the orcs. Its cruel
 D: edge was forged in Orodruth long ere the Noldor came
 D: to Beleriand.
 
-#
-# The Curved Sword 'Agarlhang'
-# - Sindarin "blood-cutlass"
-#
+## The Curved Sword 'Agarlhang'
+## - Sindarin "blood-cutlass"
+
 N:56:'Agarlhang'
 I:23:7:-2
 W:8:10:60:30000
@@ -829,6 +833,7 @@ D: in secret made of metal from a star.
 
 ## The Bastard Sword 'Luinmegil'
 ## Sindarin: blue sword
+
 N:72:'Luinmegil'
 G:|:b
 I:23:21:0
@@ -906,10 +911,9 @@ D: unwillingly to meet it of old; his lame foot will remind him of its
 D: might should he face it again.
 
 
-##
-## The Mithril Greatsword 'Ungoliant's Lament' 
+## The Mithril Greatsword 'Ungoliant's Lament'
 ## - added because we lacked any artefact mithril greatswords
-##
+
 N:83:'Ungoliant's Lament'
 I:23:30:0
 W:12:20:40:30000
@@ -920,7 +924,9 @@ D: Many spiders of the Ered Gorgoroth were slain by it in the days following
 D: the arrival of the Noldor in Beleriand.
 
 
-##### Polearms #####
+###############################################################################
+# Polearms
+###############################################################################
 
 ##
 ## The Spear 'Dugrakh'
@@ -933,7 +939,7 @@ P:1:1d11:0:0d0
 F:SLAY_RAUKO | SLAY_MAN_OR_ELF | SEE_INVIS | FREE_ACT
 F:GRA | AGGRAVATE | THROWING
 D:A weapon forged after the Dagor Bragollach by Sauron,
-D: tainted to slay Morgoth's foes whether they be man, elf or Maiar. 
+D: tainted to slay Morgoth's foes whether they be man, elf or Maiar.
 D: Black-hafted, with a bronze head, it throws no shadow.
 
 
@@ -1043,6 +1049,7 @@ D: was for many years an heirloom of the dwarven city of Nogrod.
 D: It grants its wielder strength to wield it and the power to
 D: fight some of Morgoth's foulest servants.
 
+
 ## The Great Axe 'Mazarbulbark'
 ## Khuzdul 'that-which-is-written axe'
 ## (ability 5/8 is Vengeance)
@@ -1098,9 +1105,9 @@ D:A beautiful blade on a long shaft of dark wood. It feels lively
 D: in your hands, its point guiding itself to where it is needed.
 
 
-
-##### Blunt Weapons #####
-
+###############################################################################
+# Blunt Weapons
+###############################################################################
 
 ## The Quarterstaff of Halmir
 ## 1st age namesake
@@ -1143,7 +1150,9 @@ D: following the destruction of the Two Trees, it has a haft and head of
 D: black iron banded about with red gold.
 
 
-##### Digging Tools #####
+###############################################################################
+# Digging Tools
+###############################################################################
 
 ## The Mattock 'Burkfelek'
 ## original to Sil
@@ -1157,8 +1166,9 @@ D:A mighty Dwarven mattock, forged by Gamil Zirak of old,
 D: and enchanted for both battle and mine.
 
 
-
-##### Helms/Crowns #####
+###############################################################################
+# Helms/Crowns
+###############################################################################
 
 ## The Helm of Angrod
 
@@ -1169,6 +1179,7 @@ P:0:0d0:0:1d3
 F:RES_COLD | RES_FEAR | REGEN
 D:The helm of Angrod, son of Finarfin, who perished in
 D: the Dagor Bragollach.
+
 
 ## The Helm of Curufin
 ## 1st age namesake
@@ -1183,6 +1194,7 @@ B:4/7
 D:A helm worn by Curufin, son of Feanor, whose dark schemes
 D: snared many in Beleriand.
 
+
 ## The Helm of the Oathbreaker
 ## (ability 5/8 is Vengeance)
 
@@ -1194,6 +1206,7 @@ F:TRAITOR | LIGHT_CURSE
 B:5/8
 D:A helm wrought of grey metal and the dull bones of some forgotten
 D: orc who once raised his blade against his master.
+
 
 ## The Great Helm of Dor-Lomin
 ## 1st age
@@ -1250,10 +1263,12 @@ P:1:0d0:-1:1d3
 F:SONG | RES_FIRE | RES_FEAR
 B:7/9
 D:A beautiful helm, wrought of mithril and inlaid with white stones.
-D: It rises gracefully to a tall point as sharp as any spear. 
+D: It rises gracefully to a tall point as sharp as any spear.
 
-##### Cloaks #####
 
+###############################################################################
+# Cloaks
+###############################################################################
 
 ## The Cloak of Maglor
 ## 1st age namesake
@@ -1329,7 +1344,9 @@ D:With its great black wings, might this remnant of the vampire
 D: let you pass as a messenger journeying to Morgoth?
 
 
-##### Bows #####
+###############################################################################
+# Bows
+###############################################################################
 
 ## The Shortbow of Celegorm
 ## (ability 1/3 is Ambush)
@@ -1397,8 +1414,9 @@ D:A large exquisite bow fashioned from a single horn of a slain
 D: dragon. Many are the blessings of the Eldar laid over it.
 
 
-##### Arrows #####
-
+###############################################################################
+# Arrows
+###############################################################################
 
 ## The Arrow 'Dailir'
 ## 1st age
@@ -1411,7 +1429,9 @@ P:+11:0d0:0:0d0
 D:The unerring arrow of Beleg Cuthalion.
 
 
-##### Boots #####
+###############################################################################
+# Boots
+###############################################################################
 
 ## The Pair of Boots of Finrod
 
@@ -1477,7 +1497,9 @@ D: none have been more hard-won than the crossing
 D: of the ice of the Helcaraxe.
 
 
-##### Gloves #####
+###############################################################################
+# Gloves
+###############################################################################
 
 ## The Set of Gloves of the Swallow
 ## (ability 1/1 is Fletchery)
@@ -1491,7 +1513,7 @@ B:1/1
 D:This pair of gloves bears the insignia of the House of the Swallow,
 D: who defend Gondolin from harm with their mighty bows.
 
-
+
 ## The Set of Gloves of Celebrimbor
 ## 1st age namesake
 ## (ability 6/4 is Expertise)
@@ -1558,7 +1580,9 @@ D: supple as fine leather. The hands that wear them
 D: can move more delicately and swiftly than if bare.
 
 
-##### Lights #####
+###############################################################################
+# Lights
+###############################################################################
 
 ## The Lesser Jewel of Finwe
 ## 1st age namesake
@@ -1574,8 +1598,9 @@ D: took many jewels from his treasuries. Most are now
 D: lost to the Unlight, but this one shines yet pure.
 
 
-##### Morgoth Artefacts #####
-
+###############################################################################
+# Morgoth Artefacts
+###############################################################################
 
 ## The Massive Iron Crown of Morgoth (no Silmarils)
 ## 1st age
@@ -1585,7 +1610,7 @@ N:175:of Morgoth
 I:33:50:0
 W:20:1:4000:10000000
 P:0:0d0:0:0d0:0
-F:INSTA_ART 
+F:INSTA_ART
 D:Once containing much of the power of he who is the mightiest among the
 D: Ainur, this plain iron crown now bears just three empty sockets:
 D: holes where should be stars.
@@ -1599,7 +1624,7 @@ N:176:of Morgoth
 I:33:50:4
 W:20:1:4000:10000000
 P:0:0d0:0:0d0:0
-F:INSTA_ART 
+F:INSTA_ART
 D:Containing much of the power of he who is the mightiest among the
 D: Ainur, this plain iron crown has mounted upon it the sole remaining
 D: Silmaril, greatest treasure of Middle-Earth.
@@ -1613,7 +1638,7 @@ N:177:of Morgoth
 I:33:50:5
 W:20:1:4000:10000000
 P:0:0d0:0:0d0:0
-F:INSTA_ART 
+F:INSTA_ART
 D:Containing much of the power of he who is the mightiest among the
 D: Ainur, this plain iron crown has mounted upon it the two remaining
 D: Silmarils, greatest treasures of Middle-Earth.
@@ -1627,7 +1652,7 @@ N:178:of Morgoth
 I:33:50:6
 W:20:1:4000:10000000
 P:0:0d0:0:0d0:0
-F:INSTA_ART 
+F:INSTA_ART
 D:Containing much of the power of he who is the mightiest among the
 D: Ainur, this plain iron crown has mounted upon it the three
 D: Silmarils, greatest treasures of Middle-Earth. To attempt to cut
@@ -1649,14 +1674,15 @@ D: whose wielder holds the lives of all Morgoth's servants
 D: in his hand.
 
 
-
-##### Smithing Template Artefacts #####
-##
-## These provide the limits on which flags can appear on which tvals
-##
-## The following additions are hard coded in the source:
-##   - Throwing items get Perfect Balance
-##   - War Hammers get Smithing
+###############################################################################
+# Smithing Template Artefacts
+#
+# These provide the limits on which flags can appear on which tvals.
+#
+# The following additions are hard coded in the source:
+#   - Throwing items get Perfect Balance
+#   - War Hammers get Smithing
+###############################################################################
 
 ## The Ultimate TV_SWORD
 
@@ -1674,7 +1700,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_POLEARM
@@ -1693,7 +1719,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_HAFTED
@@ -1712,7 +1738,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_DIGGING
@@ -1731,7 +1757,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_BOW
@@ -1755,7 +1781,7 @@ F:SLAY_ORC | SLAY_TROLL | SLAY_WOLF | SLAY_SPIDER
 F:SLAY_UNDEAD | SLAY_RAUKO | SLAY_DRAGON
 F:BRAND_FIRE | BRAND_COLD | BRAND_POIS
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_RING
@@ -1770,7 +1796,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | REGEN | SEE_INVIS | FREE_ACT | SPEED
 F:HUNGER | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_AMULET
@@ -1784,7 +1810,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_LIGHT
@@ -1798,7 +1824,7 @@ F:RES_FEAR | RES_BLIND | RES_HALLU
 F:LIGHT | SEE_INVIS
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_SOFT_ARMOR
@@ -1813,7 +1839,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT | SPEED
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_MAIL
@@ -1828,7 +1854,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT | SPEED
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_CLOAK
@@ -1843,7 +1869,7 @@ F:RES_FEAR | RES_CONFU | RES_STUN | RES_HALLU
 F:SLOW_DIGEST | LIGHT | REGEN | FREE_ACT
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_SHIELD
@@ -1858,7 +1884,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN
 F:LIGHT | REGEN | FREE_ACT
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_HELM
@@ -1873,7 +1899,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:LIGHT | REGEN | SEE_INVIS
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_CROWN
@@ -1888,7 +1914,7 @@ F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 F:LIGHT | REGEN | SEE_INVIS
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_GLOVES
@@ -1902,7 +1928,7 @@ F:SUST_STR | SUST_DEX
 F:FREE_ACT | RES_FIRE | RES_COLD | RES_POIS | RES_BLEED
 F:HUNGER | DANGER | AGGRAVATE | LIGHT_CURSE | DARKNESS
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
 
 ## The Ultimate TV_BOOTS
@@ -1917,11 +1943,11 @@ F:RES_FEAR | RES_CONFU | REGEN
 F:FREE_ACT | SPEED | AVOID_TRAPS
 F:HUNGER | DARKNESS | DANGER | AGGRAVATE | LIGHT_CURSE
 F:HAUNTED | FEAR | VUL_FIRE | VUL_COLD | VUL_POIS
-F:INSTA_ART 
+F:INSTA_ART
 
-
-# List of all relevant flags...
-#
+##
+## List of all relevant flags
+##
 #F:STR | DEX | CON | GRA | NEG_STR | NEG_DEX | NEG_CON | NEG_GRA
 #F:ARCHERY | STEALTH | PERCEPTION | WILL | SMITHING | SONG
 #F:DAMAGE_SIDES | CHEAT_DEATH
@@ -1934,19 +1960,21 @@ F:INSTA_ART
 #F:RES_FEAR | RES_BLIND | RES_CONFU | RES_STUN | RES_HALLU
 #F:RADIANCE | SLOW_DIGEST | LIGHT | REGEN | SEE_INVIS | FREE_ACT | SPEED
 #F:HUNGER | DARKNESS | SLOWNESS | DANGER | AGGRAVATE | LIGHT_CURSE
-#F:INSTA_ART 
+#F:INSTA_ART
 
 
-#################################################################
+###############################################################################
 # The 'Random' artefacts come next.
+#
 # They use indices 150 - 199.
-# But they are automatically generated so aren't listed here.
+# But they are automatically generated, so aren't listed here.
+###############################################################################
 
 
-#################################################################
+###############################################################################
 # The 'Self-made' artefacts come next.
+#
 # They use indices 200 - 249.
-# But they are automatically generated so aren't listed here.
-
-
+# But they are automatically generated, so aren't listed here.
+###############################################################################
 

--- a/lib/edit/artefact.txt
+++ b/lib/edit/artefact.txt
@@ -401,7 +401,7 @@ N:25:of Haldad
 I:36:4:1
 W:6:10:40:45000
 P:0:0d0:-1:1d4
-B:STR | RES_FEAR | FREE_ACT
+F:STR | RES_FEAR | FREE_ACT
 D:Leather armour worn by Haldad, father of Haleth,
 D: into his last battle where he fell fighting besieging orcs.
 

--- a/lib/edit/artefact.txt
+++ b/lib/edit/artefact.txt
@@ -6,6 +6,15 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
+#
 # === Understanding artefact.txt ===
 #
 # N: serial number : item name

--- a/lib/edit/artefact.txt
+++ b/lib/edit/artefact.txt
@@ -1,18 +1,19 @@
 # File: artefact.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/artefact.raw` file, which
 # is used to initialize the 'artefact' information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding artefact.txt ===

--- a/lib/edit/flavor.txt
+++ b/lib/edit/flavor.txt
@@ -1,18 +1,19 @@
 # File: flavor.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/flavor.raw` file, which is
 # used to initialize the "flavor" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding flavor.txt ===

--- a/lib/edit/flavor.txt
+++ b/lib/edit/flavor.txt
@@ -1,6 +1,6 @@
 # File: flavor.txt
 #
-# This file is used to create the "lib/data/flavor.raw" file, which is
+# This file is used to create the `lib/data/flavor.raw` file, which is
 # used to initialize the "flavor" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
@@ -8,18 +8,20 @@
 #
 # === Understanding flavor.txt ===
 #
-# N: index : tval : sval
+# N: index : tval [: sval]
 # G: char : attr
 # D: text
 #
 # 'N' is for the serial number (which must increase for each
-#     new item), the tval (the type of item), and the
-#     sval (the subtype). (See object.txt)
+#     new item), the tval (the type of item), and the optional
+#     sval (the subtype, only for fixed items).
+#     (See object.txt)
 #
-# 'G' is for the graphics. (See object.txt)
+# 'G' is for the graphics (see object.txt). The attr field supports
+#     base colors (D, w, s, o, r, g, b, u, d, W, v, y, R, G, B, U)
+#     and extended colors with numeric suffix (e.g., D1, v1).
 #
 # 'D' is for the name/description.
-
 
 
 # Version stamp (required)
@@ -27,7 +29,9 @@
 V:1.5.1
 
 
-##### Rings #####
+###############################################################################
+# Rings
+###############################################################################
 
 # Fixed: The Ring of Barahir
 N:1:45:32
@@ -119,8 +123,9 @@ D:Pearl
 #D:Mithril
 
 
-
-##### Amulets #####
+###############################################################################
+# Amulets
+###############################################################################
 
 # Fixed: The Pearl 'Nimphelos'
 N:41:40:13
@@ -190,7 +195,9 @@ D:Sea Shell
 #D:Mithril
 
 
-##### Staves #####
+###############################################################################
+# Staves
+###############################################################################
 
 N:68:55
 G:_:U
@@ -268,7 +275,9 @@ N:86:55
 G:_:u1
 D:Twisted
 
-##### Horns #####
+###############################################################################
+# Horns
+###############################################################################
 
 N:101:66
 G:?:W
@@ -290,7 +299,10 @@ N:105:66
 G:?:U1
 D:Engraved
 
-##### Herbs #####
+
+###############################################################################
+# Herbs
+###############################################################################
 
 N:121:80
 G:,:D
@@ -377,11 +389,9 @@ G:,:b1
 D:Bright Blue
 
 
-
-
-
-
-##### Potions #####
+###############################################################################
+# Potions
+###############################################################################
 
 # Fixed: miruvor
 N:193:75:0

--- a/lib/edit/flavor.txt
+++ b/lib/edit/flavor.txt
@@ -6,6 +6,15 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
+#
 # === Understanding flavor.txt ===
 #
 # N: index : tval [: sval]

--- a/lib/edit/history.txt
+++ b/lib/edit/history.txt
@@ -1,18 +1,19 @@
 # File: history.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/history.raw` file, which is
 # used to initialize the "player history" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding history.txt ===

--- a/lib/edit/history.txt
+++ b/lib/edit/history.txt
@@ -1,6 +1,6 @@
 # File: history.txt
 #
-# This file is used to create the "lib/data/history.raw" file, which is
+# This file is used to create the `lib/data/history.raw` file, which is
 # used to initialize the "player history" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
@@ -11,14 +11,15 @@
 # N: primary index : secondary index : probability : house
 # D: description
 #
-# 'N' the primary index represents the type of descriptive text
+# 'N' is the primary index that represents the type of descriptive text
 #     being generated (e.g. a Dwarven profession) and the secondary
 #     index gives the particular thing within this type (e.g. craftsman).
 #     The probability is the highest value of a random number from 1 to 100
 #     that will lead to this choice (so these increase through a type).
 #     Note that the races (race.txt) give primary indices into this table.
 #
-# 'D' A piece of descriptive text
+# 'D' is for description. As many D: lines may be used as are needed
+#     to describe the history.
 #
 # Background information (see below)
 #
@@ -30,9 +31,10 @@
 #  Naugrim        --> 16 --> 17 --> 18 --> 57 --> 58 --> 59 --> 60 --> 61
 #
 #
-# * Note that this table *must* be correct or drastic errors may occur!
+# === Notes ==
 #
-# * Note that the "spacing" in the "description" lines is very important!
+# * This table *must* be correct or drastic errors may occur!
+# * The spacing (whitespace) in the `D:` lines is important!
 
 
 # Version stamp (required)
@@ -40,7 +42,9 @@
 V:1.5.1
 
 
+###############################################################################
 # Noldor history
+###############################################################################
 
 N:1:2:30:0
 D:You are one of several children
@@ -70,7 +74,9 @@ N:3:50:100:3
 D:from the house of Finarfin.
 
 
+###############################################################################
 # Sindar history
+###############################################################################
 
 N:4:5:30:0
 D:You are one of several children
@@ -95,7 +101,9 @@ N:5:54:100:0
 D:of a Sindar king.
 
 
+###############################################################################
 # Naugrim History
+###############################################################################
 
 N:16:17:25:0
 D:You are one of two children of a Dwarven
@@ -121,8 +129,9 @@ N:18:57:100:0
 D:You were a well liked child.
 
 
-
+###############################################################################
 # Edain History
+###############################################################################
 
 N:21:22:5:0
 D:You are the illegitimate and unacknowledged child
@@ -146,7 +155,6 @@ D:of a warrior.
 N:22:23:100:0
 D:of a prince.
 
-
 N:23:25:10:0
 D:You are the black sheep of the family.
 N:23:25:80:0
@@ -155,7 +163,9 @@ N:23:25:100:0
 D:You were a well liked child.
 
 
+###############################################################################
 # Edain Description
+###############################################################################
 
 N:25:26:20:0
 D:You have dark brown eyes,
@@ -198,7 +208,9 @@ N:28:0:100:0
 D:and a very fair complexion.
 
 
+###############################################################################
 # Noldor description
+###############################################################################
 
 N:50:51:85:0
 D:You have light grey eyes,
@@ -226,7 +238,9 @@ N:52:0:100:0
 D:silver hair, and a fair complexion.
 
 
+###############################################################################
 # Sindar description
+###############################################################################
 
 N:54:55:85:0
 D:You have light grey eyes,
@@ -252,7 +266,9 @@ N:56:0:100:0
 D:silver hair, and a fair complexion.
 
 
+###############################################################################
 # Naugrim description
+###############################################################################
 
 N:57:58:100:0
 D:You have dark brown eyes,

--- a/lib/edit/history.txt
+++ b/lib/edit/history.txt
@@ -6,6 +6,15 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
+#
 # === Understanding history.txt ===
 #
 # N: primary index : secondary index : probability : house

--- a/lib/edit/house.txt
+++ b/lib/edit/house.txt
@@ -6,6 +6,15 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
+#
 # === Understanding house.txt ===
 #
 # N: house number : house name

--- a/lib/edit/house.txt
+++ b/lib/edit/house.txt
@@ -1,18 +1,19 @@
 # File: house.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the "lib/data/house.raw" file, which is
 # used to initialize the "player house" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding house.txt ===

--- a/lib/edit/house.txt
+++ b/lib/edit/house.txt
@@ -6,7 +6,6 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
-#
 # === Understanding house.txt ===
 #
 # N: house number : house name
@@ -14,6 +13,7 @@
 # B: short house name
 # F: house flag
 # S: str : dex : con : gra
+# D: description
 #
 # 'N' indicates the beginning of an entry. The serial number must
 #     increase for each new house.
@@ -27,6 +27,8 @@
 # 'F' is the house flags, which modify certain skills
 #
 # 'S' is the bonuses to stats: Str, Dex, Con, Gra
+#
+# 'D' is a textual description of the house
 
 
 # Version stamp (required)

--- a/lib/edit/limits.txt
+++ b/lib/edit/limits.txt
@@ -1,13 +1,42 @@
 # File: limits.txt
 #
-# This file is used to create the "lib/data/limits.raw" file, which is
+# This file is used to create the `lib/data/limits.raw` file, which is
 # used to initialize the "array sizes" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
-# These numbers are all actually the maximum + 1, (except for the artifact 
-# non-total numbers)
+# === Understanding limits.txt ===
+#
+# M:code:value
+#
+# 'M' is the limit marker followed by a code letter and one or more values.
+#
+# Limit codes:
+#   M:F:value - Max number of feature/terrain types
+#   M:K:value - Max number of object kinds
+#   M:B:value - Max number of abilities
+#   M:A:special:normal:random:self-made - Max numbers of artefacts
+#               Important note: Changing these numbers will almost always break
+#               savefile compatibility!
+#   M:E:value - Max number of special item (ego) types
+#   M:R:value - Max number of monster races
+#   M:G:value - Max number of ghost templates
+#   M:V:value - Max number of vaults
+#   M:P:value - Max number of player races
+#   M:C:value - Max number of player houses
+#   M:H:value - Max number of player history lines
+#   M:Q:value - Max number of quests
+#   M:L:value - Max number of flavors
+#   M:O:value - Max number of objects on level
+#   M:N:value - Size of names array (bytes)
+#   M:T:value - Size of descriptions array (bytes)
+#
+#
+# === Notes ===
+#
+# - These numbers are all actually the maximum + 1, (except for the artefact
+#   non-total numbers).
 
 
 # Version stamp (required)
@@ -24,18 +53,17 @@ M:K:600
 # Maximum number of abilities
 M:B:240
 
-# Maximum number of total artifacts
+# Maximum number of total artefacts
+#
+# Changing these numbers will almost always break savefile compatibility!
 #
 # M:A:special:normal:random:self-made
 #
-#   special artifacts:     (1 to this number - 1)
-#   normal artifacts:      ((special) to (special + this number - 1))
-#   random artifacts:      ((normal artifacts) to (normal artfiacts + this number - 1))
-#   self-made artfiacts:   ((random artifacts) to (random artifacts + this number - 1))
-#   total artifacts        = special + normal + random + self-made
-#
-# changing these numbers will almost always break savefile compatibility
-#
+#   special artefacts:     (1 to this number - 1)
+#   normal artefacts:      ((special) to (special + this number - 1))
+#   random artefacts:      ((normal artefacts) to (normal artefacts + this number - 1))
+#   self-made artefacts:   ((random artefacts) to (random artefacts + this number - 1))
+#   total artefacts        = special + normal + random + self-made
 M:A:20:180:1:50
 
 # Maximum number of special item types
@@ -71,12 +99,13 @@ M:O:512
 # Previously we had the maximum number of monsters on the level here
 # but it has been made into a compile-time #define
 
-#
+
+###############################################################################
 # Array sizes (in bytes) for some initialization stuff
-#
+###############################################################################
 
 # Size of the "fake" array for reading in names of monsters, objects,
-# artifacts, store-owners, player-races, ...
+# artefacts, store-owners, player-races, ...
 M:N:20480
 
 # Size of the "fake" array for reading in the descriptions of monsters,

--- a/lib/edit/limits.txt
+++ b/lib/edit/limits.txt
@@ -6,6 +6,15 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
+#
 # === Understanding limits.txt ===
 #
 # M:code:value

--- a/lib/edit/limits.txt
+++ b/lib/edit/limits.txt
@@ -1,18 +1,19 @@
 # File: limits.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/limits.raw` file, which is
 # used to initialize the "array sizes" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding limits.txt ===

--- a/lib/edit/monster.txt
+++ b/lib/edit/monster.txt
@@ -6,6 +6,13 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
 #
 # === Understanding monster.txt ===
 #

--- a/lib/edit/monster.txt
+++ b/lib/edit/monster.txt
@@ -70,7 +70,6 @@
 #     to describe the monster.
 #
 #
-#
 # === Understanding monster.txt flags ===
 #
 # UNIQUE monsters are just special monster races, with the requirement

--- a/lib/edit/monster.txt
+++ b/lib/edit/monster.txt
@@ -22,10 +22,12 @@
 # D: Description
 #
 # 'N' indicates the beginning of an entry. The serial number must
-#     increase for each new item. Entry 0 is used for the player.
+#     increase for each new item. Entry 0 is reserved for the player.
 #
-# 'W' is for more information - the depth they are found at and their rarity
-#     (they have a 1 in rarity chance of being generated).
+# 'W' is for the depth (dungeon level) the monsters are found at and their
+#     rarity. They have a 1-in-rarity chance of being generated (spawned).
+#     The depth of monsters must not be 0, because this is used to identify the
+#     player.
 #
 # 'G' is for graphics - symbol and color. There are 16 base colors, as
 #     follows:
@@ -125,7 +127,7 @@
 # Typical Dragon:  30d4 - 50d4
 # Unrelenting H:  100d4
 #       Morgoth:  200d4
-# 
+#
 # Will:
 #
 # Typical value:  dungeon level * 2/3
@@ -291,7 +293,9 @@
 V:1.5.1
 
 
-##### Non-race (contains the player picture) #####
+###############################################################################
+# Player
+###############################################################################
 
 # Noldor
 N:0:<player>
@@ -310,12 +314,17 @@ N:3:<player>
 G:@:w
 
 
-##### Dungeon monsters #####
+###############################################################################
+# Dungeon monsters are defined below.
+#
+# Monsters must not use dungeon level (depth) 0 = W:0, because this is used to
+# identify the player!
+###############################################################################
 
-# Must not have any level 0 creatures, as this is used to identify player
 
-
-##### 1 #####
+###############################################################################
+# Dungeon level 1
+###############################################################################
 
 N:11:Wolf
 W:1:1
@@ -340,7 +349,8 @@ F:NO_FEAR | RES_POIS | NO_CONF | NO_SLEEP | NO_CRIT
 D:'... great writhing, tangled brambles sprawled. Some had long stabbing
 D: thorns, some hooked barbs that rent like knives.'
 
-# Can't move from idx 13 for dungeon generation reasons
+
+# Must leave at index 13 for dungeon generation reaons.
 N:13:Dejected human thrall
 W:1:0
 G:@:g
@@ -351,7 +361,8 @@ F:MALE | MAN | NEVER_MOVE | NEVER_BLOW | SMART | PEACEFUL | SPECIAL_GEN
 D:A scarred and dirty man clad only in a loincloth. A metal collar
 D: is about his neck, and a long chain leads from it to the wall.
 
-# Can't move from idx 14 for dungeon generation reasons
+
+# Must leave at index 14 for dungeon generation reaons.
 N:14:Dejected elven thrall
 W:1:0
 G:@:g
@@ -362,7 +373,8 @@ F:MALE | ELF | NEVER_MOVE | NEVER_BLOW | SMART | PEACEFUL | SPECIAL_GEN
 D:A chained elf slumps here, filthy hair hanging to his shoulders
 D: and eyes vacant. His back and arms bear the marks of a whip.
 
-# Can't move from idx 15 for dungeon generation reasons
+
+# Must leave at index 15 for dungeon generation reaons.
 N:15:Orc thrallmaster
 W:1:0
 G:o:g
@@ -376,7 +388,8 @@ F:ORC | HURT_LITE | SMART | UNLOCK_DOOR | TERRITORIAL
 D:He is one of Morgoth's grim mockeries of the firstborn.
 D: Clad in tattered leather, he wields a cudgel and a whip.
 
-# Can't move from idx 16 for dungeon generation reasons
+
+# Must leave at index 16 for dungeon generation reaons.
 N:16:Alert human thrall
 W:1:0
 G:@:G
@@ -387,7 +400,8 @@ F:MALE | MAN | NEVER_MOVE | NEVER_BLOW | SMART | PEACEFUL | SPECIAL_GEN
 D:A scarred and dirty man shackled to the wall with a long chain.
 D: His head is raised and he takes in his surroundings alertly.
 
-# Can't move from idx 17 for dungeon generation reasons
+
+# Must leave at index 17 for dungeon generation reaons.
 N:17:Alert elven thrall
 W:1:0
 G:@:G
@@ -399,7 +413,9 @@ D:A chained elf crouches here, filthy hair hanging to his shoulders.
 D: Dried blood encrusts a noble face. His eyes are fixed on you.
 
 
-##### 2 #####
+###############################################################################
+# Dungeon level 2
+###############################################################################
 
 N:21:Orc skirmisher
 W:2:1
@@ -440,7 +456,9 @@ D:An evil swamp dwelling creature that feeds on the bones
 D: of those who draw near.
 
 
-##### 3 #####
+###############################################################################
+# Dungeon level 3
+###############################################################################
 
 N:31:Orc scout
 W:3:1
@@ -458,7 +476,7 @@ D: The miserable creature tries to stay away from you and
 D: attract attention. It has a crude spear.
 
 
-# Can't move from idx 32, used by monster ability HATCH_SPIDER
+# Must leave at index 32, used by monster ability HATCH_SPIDER.
 N:32:Spider hatchling
 W:3:2
 G:m:U
@@ -487,7 +505,9 @@ D:A snake the length of a man, with hard blue scales.
 D: There is a chill in the air around it.
 
 
-##### 4 #####
+###############################################################################
+# Dungeon level 4
+###############################################################################
 
 N:41:Orc soldier
 W:4:1
@@ -543,7 +563,9 @@ D:A huge ponderous spider with clusters of eggs on its back.
 D: Its hairy mandibles are wet with a dark fluid.
 
 
-##### 5 #####
+###############################################################################
+# Dungeon level 5
+###############################################################################
 
 
 N:51:Orc archer
@@ -602,8 +624,9 @@ D:A captain of an orcish band, Gorgol keeps his troop in
 D: order with displays of violence.
 
 
-##### 6 #####
-
+###############################################################################
+# Dungeon level 6
+###############################################################################
 
 N:61:Orc warrior
 W:6:1
@@ -660,8 +683,9 @@ D:A faded presence that perhaps once was man or elf,
 D: but is now an insubstantial thing of necromancy and shadow.
 
 
-##### 7 #####
-
+###############################################################################
+# Dungeon level 7
+###############################################################################
 
 N:71:Attercop
 W:7:1
@@ -750,11 +774,11 @@ D:A great captain of the orcs, who led many raids into the
 D: lands of the elves.
 
 
-##### 8 #####
+###############################################################################
+# Dungeon level 8
+###############################################################################
 
-
-# need to leave Orc champion at location 81
-
+# Must leave Orc champion at index 81.
 N:81:Orc champion
 W:8:2
 G:o:b
@@ -824,11 +848,11 @@ D: and carrying a short broad blade which he tosses from
 D: one hand to the other with unsettling dexterity.
 
 
-##### 9 #####
+###############################################################################
+# Dungeon level 9
+###############################################################################
 
-
-# need to leave Orc captain at location 91
-
+# Must leave Orc captain at index 91.
 N:91:Orc captain
 W:9:3
 G:o:r
@@ -899,8 +923,9 @@ S:SPELL_PCT_5 | POW_14 | RALLY
 D:The chief champion of the orcs of Morgoth.
 
 
-##### 10 #####
-
+###############################################################################
+# Dungeon level 10
+###############################################################################
 
 N:101:Whispering shadow
 W:10:1
@@ -976,9 +1001,9 @@ D: the intelligence that has kept him a favourite
 D: of the black enemy for many years.
 
 
-
-##### 11 #####
-
+###############################################################################
+# Dungeon level 11
+###############################################################################
 
 N:111:Snow troll
 W:11:1
@@ -995,8 +1020,7 @@ F:KNOCK_BACK
 D:He is a white troll with powerfully clawed hands.
 
 
-# need to leave Barrow wight at location 112
-
+# Must leave Barrow wight at index 112.
 N:112:Barrow wight
 W:11:100
 G:W:W
@@ -1058,8 +1082,7 @@ D:Son of Ulfang, the Black, and the leader in the treason against
 D: the elves in the Battle of Unnumbered Tears.
 
 
-# need to leave Aldor at location 117
-
+# Must leave Aldor at index 117.
 N:117:Aldor, the Risen King
 W:11:100
 G:W:R
@@ -1080,10 +1103,11 @@ D: this place, far from Mandos' halls. He is arrayed in
 D: finery and holds a long blade in ghostly fingers.
 
 
-##### 12 #####
+###############################################################################
+# Dungeon level 12
+###############################################################################
 
-# need to leave Easterling spy at location 121
-
+# Must leave Easterling spy at index 121.
 N:121:Easterling spy
 W:12:3
 G:@:D
@@ -1158,10 +1182,7 @@ D: their treachery. He and his sons once openly swore allegiance
 D: to the High Elves, but were secretly in the pay of Morgoth.
 
 
-
-
-# (Duruin = red flame of the night)
-
+# Duruin (red flame of the night)
 N:126:Duruin, Least of the Balrogs
 W:12:30
 G:R:o
@@ -1179,10 +1200,10 @@ D: of Morgoth's servants and widely feared. Before you stands
 D: Duruin, Flame of the Night, a great figure wrapped in fire
 D: and shadow. He wields fiery sword and whip.
 
-
 
-##### 13 #####
-
+###############################################################################
+# Dungeon level 13
+###############################################################################
 
 N:131:Werewolf
 W:13:1
@@ -1255,10 +1276,9 @@ D:Known as the giant of winter and the northern reaches,
 D: he is tall even among giants, and his name is cursed in many lands.
 
 
-
-
-##### 14 #####
-
+###############################################################################
+# Dungeon level 14
+###############################################################################
 
 N:141:Ruby serpent
 W:14:3
@@ -1302,8 +1322,7 @@ D:A chill hangs in the air around this figure which is
 D: almost that of a person. A cold gleaming blade is in its hand.
 
 
-# (Delthaur = abominable horror)
-
+# Delthauri (abominable horror)
 N:145:Delthaur, Balrog of Terror
 W:14:20
 G:R:g
@@ -1338,8 +1357,10 @@ D:Known as the giant of summer and the south, he towers above you
 D: like a great tree. In his right hand, he holds the longest
 D: sword you have ever beheld.
 
-
-##### 15 #####
+
+###############################################################################
+# Dungeon level 15
+###############################################################################
 
 N:151:Cave troll
 W:15:1
@@ -1371,7 +1392,7 @@ D:A great serpent with scales of gleaming emerald.
 D: Noxious vapours surround it.
 
 
-# Can't move from idx 153, used by monster Song of Oaths
+# Must leave at index 153, used by monster Song of Oaths.
 N:153:Oathwraith
 W:15:6
 G:W:D
@@ -1388,9 +1409,7 @@ D:A figure that seems made of void, its strangely human shape is cloaked
 D: in shadow.  It reaches out at you.
 
 
-
-# need to leave Cat warrior at location 154
-
+# Must leave Cat warrior at index 154.
 N:154:Cat warrior
 W:15:1
 G:f:U
@@ -1407,8 +1426,9 @@ D: could be natural. It moves with astonishing
 D: speed and agility.
 
 
-##### 16 #####
-
+###############################################################################
+# Dungeon level 16
+###############################################################################
 
 N:161:Amethyst serpent
 W:16:3
@@ -1458,9 +1478,7 @@ D: at every turn they silent loomed
 D: in fitful glares that leaped and died.'
 
 
-
-# need to leave Young cold-drake at location 164
-
+# Must leave Young cold-drake at index 164.
 N:164:Young cold-drake
 W:16:6
 G:d:w
@@ -1494,8 +1512,7 @@ D:This cat seems older than most, and more sly.
 D: He has long guarded the entrance to the fortress of Tevildo.
 
 
-# (Belegwath = mighty shadow)
-
+# Belegwath (mighty shadow)
 N:166:Belegwath, Balrog of Shadow
 W:16:20
 G:R:v
@@ -1529,9 +1546,9 @@ D:An insubstantial and ragged figure, scarcely to be seen.
 D: Its eyes form two dark pits in a ruined face.
 
 
-
-##### 17 #####
-
+###############################################################################
+# Dungeon level 17
+###############################################################################
 
 N:171:Spider of Gorgoroth
 W:17:1
@@ -1591,8 +1608,7 @@ D: although surely no bat could harbour so much malice
 D: behind its eyes.
 
 
-# need to leave Cat assassin at location 175
-
+# Must leave Cat assassin at index 175.
 N:175:Cat assassin
 W:17:3
 G:f:D
@@ -1626,8 +1642,7 @@ D: His claws are sharp, and by some force,  cunning or
 D: treachery his hoard is large for a young worm.
 
 
-# only ever appears in the escort of Tevildo
-
+# Oikeroi only ever appears in the escort of Tevildo.
 N:177:Oikeroi, Guard of Tevildo
 W:17:15
 G:f:o
@@ -1641,11 +1656,11 @@ D:A fierce and warlike cat, thane of Tevildo
 D: and ever at his side.
 
 
-##### 18 #####
+###############################################################################
+# Dungeon level 18
+###############################################################################
 
-
-# need to leave Young fire-drake at location 181
-
+# Must leave Young fire-drake at index 181.
 N:181:Young fire-drake
 W:18:6
 G:d:r
@@ -1717,7 +1732,6 @@ D: flocked to the banner of Melkor when the World was
 D: yet young.
 
 
-
 N:185:Tevildo, Prince of Cats
 W:18:10
 G:f:u
@@ -1733,8 +1747,7 @@ D: cat-people, is it a wonder that this fierce
 D: warrior is royalty?
 
 
-# (Turkano = powerful commander)
-
+# Turkano (powerful commander)
 N:186:Turkano, Balrog of the Hosts
 W:18:20
 G:R:b
@@ -1753,11 +1766,12 @@ D: leading a host of Raukar to bring
 D: glory after glory for his fell master.
 
 
-##### 19 #####
+###############################################################################
+# Dungeon level 19
+###############################################################################
 
-# made more 'rare' than other ancient serpents as they occur
-# natively before Morgoth's throne room and are seen much more
-
+# Made more 'rare' than other ancient serpents because they occur natively
+# before Morgoth's throne room and are seen much more.
 N:191:Ancient sapphire serpent
 W:19:6
 G:S:B
@@ -1773,8 +1787,7 @@ D:A vast serpentine form encrusted with scales of sapphire.
 D: Frost covers it from head to tail.
 
 
-# need to leave Troll guard at location 192
-
+# Must leave Troll guard at index 192.
 N:192:Troll guard
 W:19:1
 G:T:s
@@ -1853,11 +1866,9 @@ D: Who can say what twist of fate has brought him at last
 D: to that dark king's deep halls?
 
 
-
-
-
-##### 20 #####
-
+###############################################################################
+# Dungeon level 20
+###############################################################################
 
 N:201:Ancient ruby serpent
 W:20:3
@@ -1892,8 +1903,7 @@ D: The oldest of the dragons are both vast and cunning beyond
 D: the understanding of mortals.
 
 
-# need to leave Silent watcher at location 203
-
+# Must leave Silent watcher at index 203.
 N:203:Silent watcher
 W:20:10
 G:H:s
@@ -1945,8 +1955,7 @@ D: enormous wolf inhabited with a human spirit.  He is chief of all his
 D: kind.
 
 
-# (Vallach = Powerful leaping flame)
-
+# Vallach (powerful leaping flame)
 N:206:Vallach, Balrog of Sudden Flame
 W:20:20
 G:R:y
@@ -1964,8 +1973,9 @@ D: a cruel fiery axe, and moves more swiftly than should be possible in
 D: such a being.
 
 
-##### 21 #####
-
+###############################################################################
+# Dungeon level 21
+###############################################################################
 
 N:211:Ancient spider
 W:21:3
@@ -2009,7 +2019,6 @@ D:Like a graceful, humanoid bat. Its black eyes regard
 D: everything around it as prey.
 
 
-
 N:214:Dagorhir, the Elfbane
 W:21:15
 G:T:r
@@ -2022,7 +2031,6 @@ F:OPEN_DOOR | BASH_DOOR | TROLL | MALE | HURT_LITE | SMART
 F:ELFBANE | KNOCK_BACK
 D:A mountain of a troll, clad in rusted iron plates.
 D: He leads a patrol of the feared Troll Guard.
-
 
 
 N:215:Gostir, the Dread Glance
@@ -2042,8 +2050,9 @@ D:When the gaze of a worm is so deadly, what need
 D: has he fire?
 
 
-##### 22 #####
-
+###############################################################################
+# Dungeon level 22
+###############################################################################
 
 N:221:Ancient amethyst serpent
 W:22:3
@@ -2109,8 +2118,7 @@ D: spider, for the very dungeon around her is sucked
 D: of its light, that she takes to weave her deadly webs.
 
 
-# The master of the guard in Angband
-
+# Lungorthin (master of the guard in Angband)
 N:225:Lungorthin, Lord of Balrogs
 W:22:20
 G:R:w
@@ -2130,8 +2138,9 @@ D: with eyes that smoulder.  The dungeon floor where he stands is
 D: scorched by the heat of his body.
 
 
-##### 23 #####
-
+###############################################################################
+# Dungeon level 23
+###############################################################################
 
 N:231:Ancient adamant serpent
 W:23:3
@@ -2203,11 +2212,11 @@ D: deadly of her vampire race.  At first she is charming to meet, but
 D: her wings and eyes give away her true form.
 
 
-##### 24 #####
+###############################################################################
+# Dungeon level 24
+###############################################################################
 
-
-# need to leave Gothmog at location 241
-
+# Must leave Gothmog at index 241.
 N:241:Gothmog, High Captain of Balrogs
 W:24:3
 G:R:r
@@ -2227,8 +2236,7 @@ D: of flame and awesome fiery breath he saved his master from
 D: Ungoliant's rage.
 
 
-# need to leave Ungoliant at location 242
-
+# Must leave Ungoliant at index 242.
 N:242:Ungoliant, the Gloomweaver
 W:24:3
 G:M:D
@@ -2248,8 +2256,7 @@ D: blackest of darkness.  She is always ravenously hungry and would even
 D: eat herself to avoid starvation.
 
 
-# need to leave Glaurung at location 243
-
+# Must leave Glaurung at index 243.
 N:243:Glaurung, the Deceiver
 W:24:3
 G:D:y1
@@ -2270,9 +2277,8 @@ D: now to an enormous size, matched only by the size of the
 D: hoard he has gathered around him.
 
 
-# need to leave Gorthaur at location 244
-# Also known as Sauron and Thu
-
+# Gorthaur is also known as Sauron and Thu.
+# Must leave Gorthaur at index 244.
 N:244:Gorthaur, Servant of Morgoth
 W:24:3
 G:C:u
@@ -2295,17 +2301,23 @@ D: now before you as a great wolf with matted fur and glowing
 D: eyes.
 
 
-
-##### 25 #####
+###############################################################################
+# Dungeon level 25
+###############################################################################
 
 # Morgoth is a very special monster (thus the QUESTOR flag).
-# Values when angered:
-# Level,      Evasion, Armour, Attack, Damage,  Will, Perception
-# Starting,   20,      5d4,    20,     6d10,    25,   10
-# Decrowned,  22,      5d4,    20,     6d10,    25,   15
-# Hurt,       25,      5d4,    30,     7d10,    30,   20
-# Badly Hurt, 25,      7d4,    30,     7d10,    35,   25
-# Desperate,  30,      7d4,    40,     8d10,    40,   30
+#
+# His attributes change based on his anger state. The actual attributes are
+# set in `anger_morgoth()` in `src/xtra2.c`. The table below is only for
+# reference and might be outdated.
+#
+#   Level             Evasion  Armour  Attack  Damage   Will  Perception
+#   --------------------------------------------------------------------
+#   Starting              20     5d4      20    6d10     25          10
+#   Decrowned             22     5d4      20    6d10     25          15
+#   Hurt or Sils stolen   25     7d4      30    7d10     30          20
+#   Badly Hurt            25     7d4      30    7d10     35          25
+#   Desperate             30     8d4      40    8d10     40          30
 
 # This entry has an intentional duplicate stub N:252 (just below) to prevent
 # using the ID 252 for other purposes. In `graf-tiles.prf`, R:252 is used to
@@ -2336,6 +2348,7 @@ D: Grond, the mighty Hammer of the Underworld. His disgusting visage,
 D: twisted with evil, is crowned with iron, the three Silmarils forever
 D: burning him. You need to get to that crown.
 
+
 # This entry is an intentional placeholder for N:251 (just above) to prevent
 # using the ID 252 for other purposes. In `graf-tiles.prf`, R:252 is used to
 # define the tile assignment for "Morgoth without crown", whereas R:251 is for
@@ -2343,11 +2356,11 @@ D: burning him. You need to get to that crown.
 N:252:Morgoth, Lord of Darkness (without crown)
 
 
-##### Surface monster #####
+###############################################################################
+# Surface monsters
+###############################################################################
 
-
-# need to leave Carcharoth at location 253
-
+# Must leave Carcharoth at index 253.
 N:253:Carcharoth, the Jaws of Thirst
 W:25:1
 G:C:r
@@ -2375,10 +2388,9 @@ D: no flitting shade nor hunted shape,
 D: seeking from Angband to escape.
 
 
-
-
-##### Hallucinatory #####
-
+###############################################################################
+# Hallucinations
+###############################################################################
 
 N:301:Feanor, High King of the Noldor
 W:30:5
@@ -2517,7 +2529,9 @@ G:V:W
 F:UNIQUE | FEMALE
 
 
+###############################################################################
 # Further ideas...
+###############################################################################
 
 # A    white         Ilmare, Handmaid of Varda
 # A    yellow        Eonwe, Herald of Manwe

--- a/lib/edit/monster.txt
+++ b/lib/edit/monster.txt
@@ -1,18 +1,19 @@
 # File: monster.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/monster.raw` file, which is
 # used to initialize the monster race information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 # === Understanding monster.txt ===
 #

--- a/lib/edit/names.txt
+++ b/lib/edit/names.txt
@@ -1,18 +1,19 @@
 # File: names.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/names.raw` file, which is
 # used to initialize the "random name generator" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding names.txt ===

--- a/lib/edit/names.txt
+++ b/lib/edit/names.txt
@@ -6,6 +6,15 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
+#
 # === Understanding names.txt ===
 #
 # N : name

--- a/lib/edit/names.txt
+++ b/lib/edit/names.txt
@@ -1,16 +1,29 @@
 # File: names.txt
 #
-# This file is used to create the "lib/data/names.raw" file, which is
+# This file is used to create the `lib/data/names.raw` file, which is
 # used to initialize the "random name generator" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
+#
+# === Understanding names.txt ===
+#
+# N : name
+#
+# 'N' is for the word that can be used for random name generation. Every word
+#     (data record) must be unique.
+#
+# The data records should be in alphabetical order so that this file is easier
+# to maintain.
 
 
-# Format:
-# N:name
+# Version stamp (required)
 
 V:1.5.1
+
+###############################################################################
+# Words that can be used for random name generation
+###############################################################################
 
 N:adanedhel
 N:adurant

--- a/lib/edit/names.txt
+++ b/lib/edit/names.txt
@@ -55,9 +55,9 @@ N:amrod
 N:anach
 N:anar
 N:anarion
+N:anarrima
 N:ancalagon
 N:ancalimon
-N:anarrima
 N:andor
 N:andram
 N:androth
@@ -79,6 +79,7 @@ N:annatar
 N:annon
 N:annuminas
 N:apanonar
+N:ar-feiniel
 N:aradan
 N:aragorn
 N:araman
@@ -89,10 +90,9 @@ N:aras
 N:aratan
 N:aratar
 N:arathorn
-N:arda
 N:ard-galen
+N:arda
 N:aredhel
-N:ar-feiniel
 N:argonath
 N:arien
 N:armenelos
@@ -116,12 +116,12 @@ N:avathar
 N:balan
 N:balar
 N:balrog
+N:bar
 N:barad
 N:baragund
 N:barahir
 N:baran
 N:baranduin
-N:bar
 N:bauglir
 N:beleg
 N:belegaer
@@ -200,8 +200,8 @@ N:dorthonion
 N:draugluin
 N:drengist
 N:duath
-N:duinath
 N:duilwen
+N:duinath
 N:dunedain
 N:dungortheb
 N:earendil
@@ -255,8 +255,8 @@ N:eonwe
 N:ephel
 N:erchamion
 N:ereb
-N:ered
 N:erech
+N:ered
 N:eregion
 N:ereinion
 N:erellont
@@ -391,8 +391,8 @@ N:lamath
 N:lammoth
 N:lanthir
 N:laurelin
-N:leithian
 N:legolin
+N:leithian
 N:lembas
 N:lenwe
 N:linaewen
@@ -449,8 +449,8 @@ N:moria
 N:moriquendi
 N:mormegil
 N:morwen
-N:nahar
 N:naeramarth
+N:nahar
 N:namo
 N:nandor
 N:nargothrond

--- a/lib/edit/object.txt
+++ b/lib/edit/object.txt
@@ -1,18 +1,19 @@
 # File: object.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/object.raw` file, which is
 # used to initialize the 'Object Kind' information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding object.txt ===

--- a/lib/edit/object.txt
+++ b/lib/edit/object.txt
@@ -6,6 +6,14 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 #
 # === Understanding object.txt ===
 #

--- a/lib/edit/race.txt
+++ b/lib/edit/race.txt
@@ -6,6 +6,14 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 #
 # === Understanding race.txt ===
 #

--- a/lib/edit/race.txt
+++ b/lib/edit/race.txt
@@ -1,18 +1,19 @@
 # File: race.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/race.raw` file, which is
 # used to initialize the "player race" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding race.txt ===

--- a/lib/edit/special.txt
+++ b/lib/edit/special.txt
@@ -1,18 +1,19 @@
 # File: special.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/special.raw` file, which is
 # used to initialize the 'special item' information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding special.txt ===

--- a/lib/edit/special.txt
+++ b/lib/edit/special.txt
@@ -6,6 +6,14 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 #
 # === Understanding special.txt ===
 #

--- a/lib/edit/terrain.txt
+++ b/lib/edit/terrain.txt
@@ -1,18 +1,19 @@
 # File: terrain.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/terrain.raw` file, which is
 # used to initialize the "terrain feature" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding terrain.txt ===

--- a/lib/edit/terrain.txt
+++ b/lib/edit/terrain.txt
@@ -6,6 +6,14 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 #
 # === Understanding terrain.txt ===
 #

--- a/lib/edit/terrain.txt
+++ b/lib/edit/terrain.txt
@@ -1,6 +1,6 @@
 # File: terrain.txt
 #
-# This file is used to create the "lib/data/terrain.raw" file, which is
+# This file is used to create the `lib/data/terrain.raw` file, which is
 # used to initialize the "terrain feature" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
@@ -16,13 +16,15 @@
 # 'N' indicates the beginning of an entry. The serial number must
 #     increase for each new item.
 #
-# 'G' is for graphics - symbol and color. There are 16 colors, as
+# 'G' is for graphics - symbol and color. There are 16 base colors, as
 #     follows:
 #
 #     D - Dark Gray    w - White          s - Gray          o - Orange
 #     r - Red          g - Green          b - Blue          u - Brown
 #     d - Black        W - Light Gray     v - Violet        y - Yellow
 #     R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
+#
+#     Extended colors use a numeric suffix (e.g., D1, v1).
 #
 # 'M' is the index of a feature to mimic.
 #

--- a/lib/edit/vault.txt
+++ b/lib/edit/vault.txt
@@ -1,18 +1,19 @@
 # File: vault.txt
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above must be within the first 1-5 lines of this file. It is a
+# modeline for vim/neovim to parse this file as a "config" file, which
+# visually highlights `# ...` lines as comments, making this file easier to
+# parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 # This file is used to create the `lib/data/vault.raw` file, which is
 # used to initialize the "vault template" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
-#
-# -----------------------------------------------------------------------------
-# vim: ft=conf
-#
-# The line above is a modeline for vim/neovim to parse this file as a "config"
-# file, which visually highlights `# ...` lines as comments, making this file
-# easier to parse and edit for a human.
-# -----------------------------------------------------------------------------
 #
 #
 # === Understanding vault.txt ===

--- a/lib/edit/vault.txt
+++ b/lib/edit/vault.txt
@@ -1,6 +1,6 @@
 # File: vault.txt
 #
-# This file is used to create the "lib/data/vault.raw" file, which is
+# This file is used to create the `lib/data/vault.raw` file, which is
 # used to initialize the "vault template" information for Sil.
 #
 # Do not modify this file unless you know exactly what you are doing,
@@ -18,7 +18,7 @@
 # === Understanding vault.txt ===
 #
 # N: serial number : vault name
-# X: room type : depth : rarity : rows : columns
+# X: room type : depth : rarity [: rows : columns]
 # F: flag1 | flag2 | flag3 ...
 # D: lines giving full layout of vault using symbols below
 #
@@ -26,7 +26,7 @@
 #     increase for each new vault.
 #
 # 'X' is for extra information - room type, minimum depth, rarity,
-#     rows, and columns.
+#     and optionally rows and columns (inferred from D: lines if omitted?).
 #
 #     type 10 - Gates of Angband
 #     type 6  - interesting room
@@ -43,9 +43,11 @@
 #     LIGHT       - 100% chance of being permanently lit
 #     SURFACE     - generated more seldom in deeper dungeons
 #
-# 'D' lines describe the layout of the vault. Lines must be padded
-#     with spaces to fill the dimensions specified. Vaults are described
-#     with the following symbols:
+# 'D' lines describe the layout of the vault. Whitespace (including trailing
+#     whitespace) are very important and must be preserved when editing this
+#     file! Lines must be padded with spaces to fill the dimensions specified.
+#
+#     Vaults are described with the following symbols:
 #
 #     $ - outside of the vault, where corridors may be connected
 #     # - granite
@@ -96,40 +98,42 @@
 #     C - Carcharoth
 #
 
+
+###############################################################################
 # Future Vault Thoughts
 #
 # Ways to add more variety to the vault format:
 #
-#   Using a symbol such that one of that symbol becomes a secret door
-#   e.g.
+# 1. Using a symbol such that one of that symbol becomes a secret door, such as:
 #
-#   N:81:Ringway 2
-#   X:6:5:8:10:14
-#   D:$$$$$$$$$$$$
-#   D:$..........$
-#   D:$......?...$
-#   D:$..#ssss#..$
-#   D:$.?s.*.2s..$
-#   D:$..s....s..$
-#   D:$..#ssss#..$
-#   D:$..........$
-#   D:$...?......$
-#   D:$$$$$$$$$$$$
+#       N:81:Ringway 2
+#       X:6:5:8:10:14
+#       D:$$$$$$$$$$$$
+#       D:$..........$
+#       D:$......?...$
+#       D:$..#ssss#..$
+#       D:$.?s.*.2s..$
+#       D:$..s....s..$
+#       D:$..#ssss#..$
+#       D:$..........$
+#       D:$...?......$
+#       D:$$$$$$$$$$$$
 #
-#   maybe have lines:
-#   O:y:33
-#   M:u:42
-#   T:):23
+# 2. Maybe have lines:
+#       O:y:33
+#       M:u:42
+#       T:):23
 #
-#   (or O:y:Mail Corslet)
+#    or:
+#       O:y:Mail Corslet
 #
-#   for object, monster, terrain, with a symbol and then this is overridden in the map
-#   so that it represents the index listed. One issue is things at a coarse grained level
-#   currently: chest, archer, flier, wolf, vampire, raukar, spider, dragon
+#   for object, monster, terrain, with a symbol. And then this is overridden in
+#   the map so that it represents the index listed. One issue is things at a
+#   coarse grained level currently: chest, archer, flier, wolf, vampire, raukar,
+#   spider, dragon
 #
-# Maybe add a max-depth for vaults
-#
-
+# 3. Maybe add a max-depth for vaults?
+###############################################################################
 
 
 # Version stamp (required)
@@ -141,7 +145,7 @@ V:1.5.1
 
 N:1:The Gates of Angband
 X:10:0:1
-F:NO_ROTATION 
+F:NO_ROTATION
 D:################################################################
 D:#......#####################.......######################......#
 D:#.oooo.+.........:##########.#...#.###########.:....:...+.oooo.#
@@ -175,8 +179,10 @@ D:##################:.:.........................##################
 D:#################...............................################
 D:#################..................................#############
 
-### interesting rooms (type 6) -- maximum size 44x22 ??? ###
 
+###############################################################################
+# Interesting rooms (type 6) -- maximum size 44x22 ?
+###############################################################################
 
 N:10:Tiny Room
 X:6:1:20
@@ -371,7 +377,7 @@ D:######$$$$$$
 
 N:45:Thin Cross
 X:6:8:4
-F:NO_ROTATION 
+F:NO_ROTATION
 D:      $$$$$$      
 D:      $....$      
 D:      $....$      
@@ -388,7 +394,7 @@ D:      $$$$$$
 
 N:46:Collapsed Cross
 X:6:12:12
-F:NO_ROTATION 
+F:NO_ROTATION
 D:      $$$$$$      
 D:      $....$      
 D:      $..#.$      
@@ -405,7 +411,7 @@ D:      $$$$$$
 
 N:47:Corridor Cross
 X:6:2:3
-F:NO_ROTATION 
+F:NO_ROTATION
 D:     #$$$$$#     
 D:     $.....$     
 D:     $.?...$     
@@ -422,7 +428,7 @@ D:     #$$$$$#
 
 N:48:Hourglass
 X:6:3:3
-F:NO_ROTATION 
+F:NO_ROTATION
 D:$$$$$$$$$
 D:$.......$
 D:$..?....$
@@ -563,7 +569,7 @@ D:$$#########$$
 
 N:59:Slave mine
 X:6:2:1
-F:SURFACE 
+F:SURFACE
 D:#######$$$$$
 D:#:::##%....$
 D:#:z.%%:z.#.$
@@ -577,7 +583,7 @@ D:$$$$$$######
 
 N:60:Maze
 X:6:5:1
-F:NO_ROTATION 
+F:NO_ROTATION
 D:$$$$$$$$$$$$$$$
 D:$.......#.....$
 D:$.#.###.#.#.#.$
@@ -591,7 +597,7 @@ D:$$$$$$$$$$$$$$$
 
 N:61:Maze 2
 X:6:5:1
-F:NO_ROTATION 
+F:NO_ROTATION
 D:$$$$$$$$$$$$$$$$$
 D:$......#....#...$
 D:$#####...##.###.$
@@ -681,7 +687,7 @@ D:       $$$$$$
 
 N:67:Forge Maze
 X:6:10:6
-F:NO_ROTATION 
+F:NO_ROTATION
 D:$$$$$$$$$$$$$$$$
 D:$#...........#.$
 D:$..####.####.#.$
@@ -958,7 +964,6 @@ D:#.###.###.#
 D:#a.......a#
 D:#####.#####
 D:    #$#    
-
 
 
 N:110:Diamond Centre
@@ -1408,6 +1413,7 @@ D:##.?.%%%...##
 D: ##...+...## 
 D:  #$$$$$$$#  
 
+
 N:204:Alcoved forge
 X:6:9:20
 D:#$$$$####
@@ -1465,9 +1471,9 @@ D:#?..#?.#.1#
 D:#####$#####
 
 
-
-####### Dragons
-
+###############################################################################
+# Dragons
+###############################################################################
 
 N:220:Dragon Lair 1
 X:6:12:5
@@ -1492,8 +1498,9 @@ D:$.....#..&#
 D:$$$$$$#####
 
 
-####### Barrows
-
+###############################################################################
+# Barrows
+###############################################################################
 
 N:230:Barrow 1
 X:6:8:5
@@ -1561,9 +1568,9 @@ D: ##...##
 D:  #$$$#  
 
 
-
-####### Chasms
-
+###############################################################################
+# Chasms
+###############################################################################
 
 N:240:A path between
 X:6:2:4
@@ -1742,7 +1749,6 @@ D: ##.............$
 D:  $$$$$$$$$$$$$$$   
 
 
-
 N:268:Chasm gauntlet
 X:6:6:20
 D:#########
@@ -1846,7 +1852,8 @@ D:   #777#
 D:   ##$##   
 
 
-# more:
+###############################################################################
+# More:
 # - a chasm that is only crossable in one direction
 # - a chasm with a treasure only reachable with blasting
 # - a chasm with a room in the middle
@@ -1855,10 +1862,11 @@ D:   ##$##
 # - a Silent Watcher on an island
 # - chasm as a minor feature in a normal interesting room or vault
 # - chasms in Gothmog's vault
+###############################################################################
 
-
-### lesser Vaults (type 7) -- maximum size 44x22 ??? ###
-
+###############################################################################
+# Lesser Vaults (type 7) -- maximum size 44x22 ?
+###############################################################################
 
 N:300:Oval Chambers
 X:7:0:1
@@ -2281,7 +2289,6 @@ D:    ######
 
 
 # (Taken directly from the brickwork of an Oxford college)
-
 N:361:Keble
 X:7:11:10
 F:NO_ROTATION
@@ -2456,14 +2463,11 @@ D:  ##$#$##
 #D:$$$$#######
 
 
-
-
-
-### Greater Vaults (type 8) -- maximum size 66x44 ??? ###
-
+###############################################################################
+# Greater Vaults (type 8) -- maximum size 66x44 ?
+###############################################################################
 
 # Aldor's vault
-
 N:400:the Tomb of the King
 X:8:8:1
 F:NO_ROTATION
@@ -2557,7 +2561,6 @@ D:########################$$$#
 
 
 # Glaurung's vault
-
 N:404:the Hoard of the Worm of Greed
 X:8:18:1
 D:$$$$###################
@@ -2606,11 +2609,13 @@ D:#.*######~s......#....######
 D:###########$$$$$$#$$$$######
 
 
-### Morgoth's vault (type 9) ###
+###############################################################################
+# Morgoth's vault (type 9)
+###############################################################################
 
 N:450:Morgoth's throne room
 X:9:20:1
-F:NO_ROTATION 
+F:NO_ROTATION
 D:###################################
 D:##&...+.####..#####..##......######
 D:#&..#.#...+..#######..#.#..#.######

--- a/lib/edit/vault.txt
+++ b/lib/edit/vault.txt
@@ -6,6 +6,14 @@
 # Do not modify this file unless you know exactly what you are doing,
 # unless you wish to risk possible system crashes and broken savefiles.
 #
+# -----------------------------------------------------------------------------
+# vim: ft=conf
+#
+# The line above is a modeline for vim/neovim to parse this file as a "config"
+# file, which visually highlights `# ...` lines as comments, making this file
+# easier to parse and edit for a human.
+# -----------------------------------------------------------------------------
+#
 #
 # === Understanding vault.txt ===
 #

--- a/lib/edit/vault.txt
+++ b/lib/edit/vault.txt
@@ -19,15 +19,14 @@
 # === Understanding vault.txt ===
 #
 # N: serial number : vault name
-# X: room type : depth : rarity [: rows : columns]
+# X: room type : depth : rarity
 # F: flag1 | flag2 | flag3 ...
 # D: lines giving full layout of vault using symbols below
 #
 # 'N' indicates the beginning of an entry. The serial number must
 #     increase for each new vault.
 #
-# 'X' is for extra information - room type, minimum depth, rarity,
-#     and optionally rows and columns (inferred from D: lines if omitted?).
+# 'X' is for extra information - room type, minimum depth, and rarity.
 #
 #     type 10 - Gates of Angband
 #     type 6  - interesting room
@@ -1809,7 +1808,7 @@ D:    $$$$$$#$$
 
 
 N:281:Maze with chasm
-X:6:5:5:9:15
+X:6:5:5
 F:NO_ROTATION
 D:$$$$$$$$$$$$$$$
 D:$.......#.....$

--- a/lib/xtra/graf/osx_bmp2png.py
+++ b/lib/xtra/graf/osx_bmp2png.py
@@ -61,8 +61,9 @@ numpy (1.7 or later)
 """
 
 import argparse
-import PIL.Image
+
 import numpy
+import PIL.Image
 
 aparser = argparse.ArgumentParser(description='Converts bmp tile set to png.')
 aparser.add_argument('input_file', type=str,


### PR DESCRIPTION
## Scope

- All game data files at `lib/edit/*.txt` are now validated via respective `bin/data-*.py` scripts.
- All game data files can now be exported from their custom `N:...` formats to JSON, via the same Python scripts.
- No actual data records were changed (with one exception being a bug fix, see below). This means no savefiles should be broken because of this PR.
- Improved the documentation of each txt file's format/rules in the comment section at the top of a file. Also, made the formatting more consistent across the various `*.txt` files.

## Notes

- In two cases (`artefact.txt` and `monster.txt`), git diff will show that the entire file was changed. As I learned after submitting this PR, this is is the result of a line encodings change: `artefact.txt` and `monster.txt` where the only two data files in the repository that were still using CLRLF+CR line encodings vs. LF (Unix) for all the other `*.txt` files. If you use `git diff --ignore-cr-at-eol` for `artefact.txt` and `monster.txt`, then git will show the actual changes (several lines instead of all lines).

## Bugs fixed

- The validation scripts already spotted one bug that I subsequently fixed in this PR: The feature flags of `The Leather Armour of Haldad` (`artefact.txt`) were set with a `B:` line instead of a `F:` line.
