### PR TITLE
fix: linker warning about __DATA__ alignment on macOS (fixes #202)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,13 @@ endif()
 # Compiler warnings used by all platforms
 target_compile_options(${SIL_TARGET} PRIVATE -Wall -Wextra)
 
+# Apple's Xcode Clang still defaults to -fcommon (unlike upstream LLVM Clang and
+# GCC 10+). This causes linker warnings about reducing alignment of __DATA,__common.
+# See: https://ffmpeg.org/pipermail/ffmpeg-cvslog/2025-May/148334.html
+if (APPLE)
+    target_compile_options(${SIL_TARGET} PRIVATE -fno-common)
+endif()
+
 # Extended compiler warnings for Linux and (non-Cocoa) macOS builds
 if (NOT WIN32 AND NOT SUPPORT_COCOA_FRONTEND)
     target_compile_options(${SIL_TARGET} PRIVATE

--- a/lib/docs/CHANGELOG.md
+++ b/lib/docs/CHANGELOG.md
@@ -104,6 +104,9 @@ Changed:
 
 Fixed:
 
+- fix: linker warning about `__DATA__` alignment on macOS (fixes #202)
+  ([#204](https://github.com/sil-quirk/sil-q/pull/204))
+  - thanks @backwardsEric
 - fix: use `F:` for feature flags of The Leather Armour of Haldad
 - Fix inconsistent house naming for Falathrim and Haleth (fixes #164)
   ([#173](https://github.com/sil-quirk/sil-q/pull/173))


### PR DESCRIPTION
Apple's Xcode Clang still defaults to `-fcommon` (unlike upstream LLVM Clang and GCC 10+). This causes linker warnings about reducing alignment of `__DATA,__common`.

See: https://ffmpeg.org/pipermail/ffmpeg-cvslog/2025-May/148334.html