### PR TITLE
add flake.nix for building with nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,11 @@
 # Build sil-q with Nix.
 #
 # This flake provides reproducible builds of sil-q using cmake + ninja.
-# It is intentionally scoped to proving the build works — not packaging for
-# distribution. Distro packaging (install locations, desktop integration,
-# runtime path wrapping, game data management) belongs in downstream package
-# definitions like nixpkgs' package.nix.
+# The default build includes game data and path wrapping so the binary
+# runs immediately.
 #
 # The mkSilQ function parameterizes the X11 frontend. Additional cmake flags
-# can be threaded in as needed. Named packages cover the standard Linux build
-# configurations; others can be built by calling mkSilQ directly from a
-# downstream flake.
+# can be threaded in as needed.
 #
 # Usage:
 #
@@ -36,7 +32,7 @@
 
           src = ./.;
 
-          nativeBuildInputs = with pkgs; [ cmake ninja pkg-config ];
+          nativeBuildInputs = with pkgs; [ cmake ninja pkg-config makeWrapper ];
           buildInputs = with pkgs;
             [ ncurses ]
             ++ pkgs.lib.optionals x11 [ pkgs.libx11 ];
@@ -47,8 +43,10 @@
           ];
 
           installPhase = ''
-            mkdir -p $out/bin
+            mkdir -p $out/bin $out/share/sil-q
             cp sil $out/bin/
+            cp -a $src/lib/* $out/share/sil-q/
+            wrapProgram $out/bin/sil --set ANGBAND_PATH $out/share/sil-q
           '';
         };
     in

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+# Build sil-q with Nix.
+#
+# This flake provides reproducible builds of sil-q using cmake + ninja.
+# It is intentionally scoped to proving the build works — not packaging for
+# distribution. Distro packaging (install locations, desktop integration,
+# runtime path wrapping, game data management) belongs in downstream package
+# definitions like nixpkgs' package.nix.
+#
+# The mkSilQ function parameterizes the X11 frontend. Additional cmake flags
+# can be threaded in as needed. Named packages cover the standard Linux build
+# configurations; others can be built by calling mkSilQ directly from a
+# downstream flake.
+#
+# Usage:
+#
+#   nix build                        # X11 + GCU (cmake Linux default)
+#   nix build .#sil-q                # same
+#   nix build .#sil-q-nox            # GCU only, no X11
+#
+# Enter a development shell (cmake, ninja, gcc, ncurses, libX11):
+#
+#   nix develop
+#
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      mkSilQ = { x11 ? true }:
+        pkgs.stdenv.mkDerivation {
+          pname = "sil-q";
+          version = "1.5.1.0-beta1";
+
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [ cmake ninja pkg-config ];
+          buildInputs = with pkgs;
+            [ ncurses ]
+            ++ pkgs.lib.optionals x11 [ pkgs.libx11 ];
+
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DSUPPORT_X11_FRONTEND=${if x11 then "ON" else "OFF"}"
+          ];
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp sil $out/bin/
+          '';
+        };
+    in
+    {
+      packages.${system} = {
+        default = self.packages.${system}.sil-q;
+        sil-q = mkSilQ {};
+        sil-q-nox = mkSilQ { x11 = false; };
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [ cmake ninja pkg-config gcc ncurses libx11 ];
+      };
+    };
+}


### PR DESCRIPTION
I'm not sure if this is helpful or interesting, but I wanted to build sil-q without
affecting my underlying Arch environment.  I have other flakes which can build sil-q
with clang or zig, static or dynamic.  This was mostly a learning exercise for me, but
I thought it might be useful for others.

