### PR TITLE
fix: Windows tile sizing on first launch and for wide fonts

### DIFF
--- a/lib/docs/CHANGELOG.md
+++ b/lib/docs/CHANGELOG.md
@@ -165,6 +165,8 @@ Changed:
 
 Fixed:
 
+- fix: Windows tile sizing on first launch and for wide fonts
+  ([#217](https://github.com/sil-quirk/sil-q/pull/217))
 - fix: swapped red/blue channels when loading 24-bit BMP tiles under X11
   ([d6075b0](https://github.com/sil-quirk/sil-q/commit/d6075b0))
 - fix: linker warning about `__DATA__` alignment on macOS (fixes #202)

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -716,16 +716,31 @@ static bool check_file(cptr s)
     return (TRUE);
 }
 
-int get_tile_height_from_font_height(int font_height)
+/*
+ * Tile cell dimensions for the bigtile rendering mode.
+ *
+ * Assumes `use_bigtile` is TRUE when tiles are active. In that mode, each tile
+ * spans two character cells horizontally (cf. `Term_pict_win()`), so the
+ * rendered tile is `(2 * tile_wid) by tile_hgt`. The cell is sized so that:
+ *
+ *   - tile_hgt == 2 * tile_wid, keeping the rendered tile square to match the
+ *     source bitmap's aspect ratio.
+ *   - tile_wid >= font_wid, so Term_text_win's per-glyph centring
+ *     (`rc.left += (tile_wid - font_wid) / 2`) doesn't go negative and spill
+ *     characters into neighbouring cells.
+ *
+ * A floor of 8 (for font_hgt <= 16) or 16 (otherwise) on tile_wid avoids
+ * shrinking tile bitmaps below a legible size when the font is small.
+ */
+int get_tile_width_from_font(int font_wid, int font_hgt)
 {
-    return font_height > 16 ? 32 : 16;
+    int w = (font_hgt > 16) ? 16 : 8;
+    return (w < font_wid) ? font_wid : w;
 }
 
-int get_tile_width_from_font_height(int font_height)
+int get_tile_height_from_font(int font_wid, int font_hgt)
 {
-    // Assumes that use_bigtile will always be true
-    // when tiles are active.
-    return font_height > 16 ? 16 : 8;
+    return 2 * get_tile_width_from_font(font_wid, font_hgt);
 }
 
 /*
@@ -1559,8 +1574,9 @@ static void term_change_font(term_data* td)
         /* Reset the tile info */
         if (arg_graphics == GRAPHICS_MICROCHASM)
         {
-            td->tile_wid = get_tile_width_from_font_height(td->font_hgt);
-            td->tile_hgt = get_tile_height_from_font_height(td->font_hgt);
+            td->tile_wid = get_tile_width_from_font(td->font_wid, td->font_hgt);
+            td->tile_hgt
+                = get_tile_height_from_font(td->font_wid, td->font_hgt);
         }
         else
         {
@@ -2665,6 +2681,15 @@ static void init_windows(void)
     /* Load prefs */
     load_prefs();
 
+    /* Keep `use_bigtile` in sync with `arg_graphics`. On a fresh install with
+     * no .ini file, `load_prefs()` defaults `arg_graphics` ("Graphics" in the
+     * .ini file) to GRAPHICS_MICROCHASM but `use_bigtile` ("Bigtile" in the
+     * .ini file) to FALSE, which leaves tiles drawn at half-width until the
+     * user toggles tiles graphics off and on. The GRAPHICS_MICROCHASM toggle
+     * handler always pairs these; do the same here so first-run state matches.
+     */
+    use_bigtile = (arg_graphics == GRAPHICS_MICROCHASM);
+
     /* Main window (need these before term_getsize gets called) */
     td = &data[0];
     td->dwStyle = (WS_OVERLAPPED | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX
@@ -2702,6 +2727,20 @@ static void init_windows(void)
             /* Oops */
             td->tile_wid = 8;
             td->tile_hgt = 13;
+        }
+
+        /* Mirror the GRAPHICS_MICROCHASM toggle handler: when `arg_graphics`
+         * is GRAPHICS_MICROCHASM, the main window's `tile_wid`/`tile_hgt`
+         * ("TileWid"/"TileHgt" in the .ini file) are derived from the font
+         * dimensions, not from what was saved in the .ini. Without this, a
+         * fresh install starts with `tile_hgt` == `font_hgt` instead of the
+         * bigtile-derived value, and tiles render at the wrong size until
+         * the user toggles tiles graphics off and on. */
+        if ((i == 0) && (arg_graphics == GRAPHICS_MICROCHASM))
+        {
+            td->tile_wid = get_tile_width_from_font(td->font_wid, td->font_hgt);
+            td->tile_hgt
+                = get_tile_height_from_font(td->font_wid, td->font_hgt);
         }
 
         /* Analyze the font */
@@ -3184,8 +3223,9 @@ static void process_menus(WORD wCmd)
 
             td = &data[0];
 
-            td->tile_wid = get_tile_width_from_font_height(td->font_hgt);
-            td->tile_hgt = get_tile_height_from_font_height(td->font_hgt);
+            td->tile_wid = get_tile_width_from_font(td->font_wid, td->font_hgt);
+            td->tile_hgt
+                = get_tile_height_from_font(td->font_wid, td->font_hgt);
 
             /* Analyze the font */
             term_getsize(td);


### PR DESCRIPTION
Background
----------
Two related bugs caused incorrect tile width/height on Windows:

1. `get_tile_*_from_font_height()` picked tile_wid from font_hgt alone (16 for font_hgt > 16, otherwise 8), ignoring font_wid. `Term_text_win()` centers each glyph in its cell via `rc.left += (tile_wid - font_wid) / 2`, so when `tile_wid < font_wid`, then the offset becomes negative and characters draw into neighbouring cells. Three bundled fonts are affected by this: 9x15, 9x15b (from prior releases), and the newly added spleen-32x64.

2. On a fresh install with no .ini file, `load_prefs()` defaults `arg_graphics` to GRAPHICS_MICROCHASM but `use_bigtile` to FALSE, and `load_prefs_aux()` defaults tile_wid/tile_hgt to the font's own width/height instead of the bigtile-derived values. Tiles render at half width until the user toggles tiles graphics off and on as a workaround, which runs the GRAPHICS_MICROCHASM toggle handler and repairs both pieces of state.

Fix
---
Rename `get_tile_*_from_font_height()` to `get_tile_*_from_font()`, take font_wid as a parameter, and raise the historical tile_wid to font_wid when it falls below. tile_hgt is computed as 2 * tile_wid to keep the bigtile-rendered tile square.

1. Every font where the historical choice already produced tile_wid >= font_wid is unchanged.
2. The three broken fonts now get cells wide enough for their glyphs (9x18 for 9x15 and 9x15b; 32x64 for spleen-32x64).

In init_windows(), apply the toggle handler's pairings: force `use_bigtile = (arg_graphics == GRAPHICS_MICROCHASM)` after `load_prefs()`, and after term_force_font() succeeds for the main window, recompute tile_wid/tile_hgt via the new helpers when graphics is on.