### PR TITLE
Add sil.exe and sil.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ src/sil
 src/sil.o.arm64
 src/sil.o.x86_64
 /Sil.app
+sil.exe
+sil.ini
 # Same as `src/sil`
 /sil
 .DS_Store


### PR DESCRIPTION
When compiling (and running) on Windows, sil.exe and sil.ini will end up in the root project root. This will ignore them from check in if they are there.