### PR TITLE
Subwindow from main crash (fixes #225)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ src/sil
 src/sil.o.arm64
 src/sil.o.x86_64
 /Sil.app
+sil.exe
+sil.ini
 # Same as `src/sil`
 /sil
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ src/sil
 src/sil.o.arm64
 src/sil.o.x86_64
 /Sil.app
-sil.exe
-sil.ini
 # Same as `src/sil`
 /sil
 .DS_Store

--- a/src/xtra1.c
+++ b/src/xtra1.c
@@ -3569,6 +3569,10 @@ void window_stuff(void)
     if (!p_ptr->window)
         return;
 
+    /* Character is not ready yet, no screen updates */
+    if (!character_generated)
+        return;
+
     /* Scan windows */
     for (j = 0; j < ANGBAND_TERM_MAX; j++)
     {


### PR DESCRIPTION
Should keep sub-window crash from occurring, return if no character has been generated.