### PR TITLE
allow debug build to have get-task-allow entitlements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,13 @@ if (SUPPORT_COCOA_FRONTEND)
             "$<TARGET_BUNDLE_CONTENT_DIR:${SIL_TARGET}>/MacOS/${SIL_EXECUTABLE}"
     )
 
+    # Entitlements used only by Debug builds. The get-task-allow entitlement
+    # lets Xcode's tracing tools (Instruments' Leaks target, for example) attach
+    # to the running app. It must never ship in a release: it makes the bundle
+    # non-distributable and weakens the process's security posture.
+    set(SIL_DEBUG_ENTITLEMENTS
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/cocoa/get-task-allow.plist")
+
     # Post-build steps
     add_custom_command(TARGET ${SIL_TARGET} POST_BUILD
         # Set bundle bit
@@ -529,8 +536,14 @@ if (SUPPORT_COCOA_FRONTEND)
         COMMAND xattr -rc "$<TARGET_BUNDLE_DIR:${SIL_TARGET}>"
         # Clean metadata
         COMMAND dot_clean -m "$<TARGET_BUNDLE_DIR:${SIL_TARGET}>"
-        # Codesign
-        COMMAND codesign --force --deep --sign - "$<TARGET_BUNDLE_DIR:${SIL_TARGET}>"
+        # Codesign. Debug also gets get-task-allow so Instruments can attach.
+        # Keep the flag and path separate: a ";" joining them would be treated
+        # as a command separator. Other configs drop both, leaving signing
+        # unchanged.
+        COMMAND codesign --force --deep
+            $<$<CONFIG:Debug>:--entitlements>
+            $<$<CONFIG:Debug>:${SIL_DEBUG_ENTITLEMENTS}>
+            --sign - "$<TARGET_BUNDLE_DIR:${SIL_TARGET}>"
         COMMENT "Signing ${SIL_NAME}.app"
     )
 

--- a/lib/docs/COMPILING.md
+++ b/lib/docs/COMPILING.md
@@ -106,6 +106,10 @@ This generates a universal macOS application, `Sil.app`, in the top-level
 directory of Sil-Q. You may move `Sil.app` to wherever you like, such as your
 Mac's `Applications` folder.
 
+> NOTE: Building with `-DCMAKE_BUILD_TYPE=Debug` instead signs the app with the
+> `get-task-allow` entitlement, which Xcode's Instruments needs in order to
+> attach to a running Sil-Q. Release builds are not signed with it.
+
 **Step 3**: Run Sil-Q via the `Sil.app` application.
 
 ```shell

--- a/src/cocoa/get-task-allow.plist
+++ b/src/cocoa/get-task-allow.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
closes #221 

Updates `CMakeLists.txt` to allow the entitlements plist to be included when signing as a debug build so the resulting .app can be launched by Xcode tools.

Changes

```
        COMMAND codesign --force --deep --sign - "$<TARGET_BUNDLE_DIR:${SIL_TARGET}>"
```

to

```
        COMMAND codesign --force --deep
            $<$<CONFIG:Debug>:--entitlements>
            $<$<CONFIG:Debug>:${SIL_DEBUG_ENTITLEMENTS}>
            --sign - "$<TARGET_BUNDLE_DIR:${SIL_TARGET}>"
```

a Release build drops the two debug entries and it'll sign as before. I tried a couple different combinations like having the complete entitlements flags be inserted. Something like

```
    set(SIL_ENTITLEMENT_FLAGS
        $<$<CONFIG:Debug>:--entitlements>
        $<$<CONFIG:Debug>:${CMAKE_CURRENT_SOURCE_DIR}/src/cocoa/get-task-allow.plist>)
```

and

```
        COMMAND codesign --force --deep ${SIL_ENTITLEMENT_FLAGS}
            --sign - "$<TARGET_BUNDLE_DIR:${SIL_TARGET}>"
```

but decided it was a tad clearer around what was happening the way the PR is being submitted.

<img width="1440" height="867" alt="Screenshot 2026-08-04 at 11 58 25 PM" src="https://github.com/user-attachments/assets/236f69a9-38a9-4c46-9500-26a432d2a6e6" />
